### PR TITLE
Add Ability to Get a RandomThought (get /random_thoughts/{id} )

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ end
    # Development and Test add RSpec, FactoryBot, and Swagger Specs
    group :development, :test do
      gem 'factory_bot_rails'
+     gem 'faker'
      gem 'rspec-rails'
      # Swagger specs
      gem 'rswag-specs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (3.1.0)
+      i18n (>= 1.8.11, < 2)
     globalid (1.0.1)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -191,6 +193,7 @@ DEPENDENCIES
   bootsnap
   debug
   factory_bot_rails
+  faker
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.4)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ mounted into the container.
 
 ---
 
+## API Endpoints
+This API contains the following endpoints...
+
+* **Show** random thought {id}: `get /random_thoughts/{id}`
+  (e.g. http://localhost:3000/random_thoughts/1)
+
 ## Development
 This project can be developed using the supplied basic, container-based
 development environment which includes `vim`, `git`, `curl`, and `psql`.
@@ -72,6 +78,71 @@ visibility and access.
   be accessed on the host machine with the database connection string
   `postgresql://random_thoughts_api:banana@localhost:5432/random_thoughts_api`
   (e.g. `psql postgresql://random_thoughts_api:banana@localhost:5432/random_thoughts_api`)
+
+---
+
+## Operating
+
+### Database
+This project uses a Rails-supported PostgreSQL database with
+the same configuration in all environments.
+
+Use the `DATABASE_URL`environment variable set to a standard
+database connection string to specify the database.
+
+It is recommended to use the official
+[PostgreSQL Docker image](https://hub.docker.com/_/postgres)
+without a persistent volume (data) for the `development`
+and `test` environments.
+
+#### Seed Data
+
+There is one sample record which can be added repeatedly.
+
+Run the following command to add a seed record...
+```
+bundle exec bin/rails db:seed
+```
+
+### Testing
+If you are using the same database for `development` and `test`,
+run the following command first to set the database for the
+`test` environment...
+```
+bundle exec bin/rails db:environment:set RAILS_ENV=test
+```
+
+Run the following command to run the tests...
+```
+bundle exec rspec
+```
+
+> :warning: If you are using the same database for `development`
+> and `test`, these steps can destroy any data in your
+> `development` database.
+
+### Running the Application
+Run the following command to run the Rails server...
+```
+bundle exec bin/rails server -p 3000 -b 0.0.0.0
+```
+
+---
+
+## Swagger
+
+### To Generate the Swagger File
+
+Run the following command to generate the Swagger file for the
+application...
+```
+bundle exec bin/rails rswag:specs:swaggerize
+```
+
+### Swagger UI
+
+By default the Swagger UI is located at http://localhost:3000/api-docs/
+
 
 ---
 

--- a/app/controllers/random_thoughts_controller.rb
+++ b/app/controllers/random_thoughts_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Implements CRUD operations for RandomThought
+class RandomThoughtsController < ApplicationController
+  def show
+    @random_thought = RandomThought.find(params[:id])
+    render json: @random_thought, only: %i[id thought name]
+  end
+end

--- a/app/models/random_thought.rb
+++ b/app/models/random_thought.rb
@@ -1,0 +1,2 @@
+class RandomThought < ApplicationRecord
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :random_thoughts, only: [:show]
   mount Rswag::Api::Engine => '/api-docs'
   mount Rswag::Ui::Engine => '/api-docs'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20230124225128_create_random_thoughts.rb
+++ b/db/migrate/20230124225128_create_random_thoughts.rb
@@ -1,0 +1,10 @@
+class CreateRandomThoughts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :random_thoughts do |t|
+      t.string :thought
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2023_01_24_225128) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "random_thoughts", force: :cascade do |t|
+    t.string "thought"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,4 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+# frozen_string_literal: true
+
+# Create the first random thought to get it started
+RandomThought.create(thought: 'This is fine', name: 'Question Hound')

--- a/spec/factories/random_thoughts.rb
+++ b/spec/factories/random_thoughts.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :random_thought do
+    thought { Faker::Lorem.sentence }
+    name { Faker::Name.name }
+  end
+end

--- a/spec/models/random_thought_spec.rb
+++ b/spec/models/random_thought_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe RandomThought, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/get_random_thought_spec.rb
+++ b/spec/requests/get_random_thought_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'get /random_thoughts/{id}' do
+  context 'when {id} exists' do
+    let(:random_thought) { create(:random_thought) }
+
+    before do
+      get random_thought_path(random_thought)
+    end
+
+    it 'returns "id": id' do
+      expect(json_body['id']).to eql(random_thought.id)
+    end
+
+    it 'returns "thought": thought' do
+      expect(json_body['thought']).to eql(random_thought.thought)
+    end
+
+    it 'returns "name": name' do
+      expect(json_body['name']).to eql(random_thought.name)
+    end
+  end
+
+  def json_body
+    JSON.parse(response.body)
+  end
+end

--- a/spec/requests/random_thoughts_spec.rb
+++ b/spec/requests/random_thoughts_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'random_thoughts', type: :request do
+
+  # path '/random_thoughts' do
+
+    # get('list random_thoughts') do
+    #   response(200, 'successful') do
+
+    #     after do |example|
+    #       example.metadata[:response][:content] = {
+    #         'application/json' => {
+    #           example: JSON.parse(response.body, symbolize_names: true)
+    #         }
+    #       }
+    #     end
+    #     run_test!
+    #   end
+    # end
+
+  #   post('create random_thought') do
+  #     response(200, 'successful') do
+
+  #       after do |example|
+  #         example.metadata[:response][:content] = {
+  #           'application/json' => {
+  #             example: JSON.parse(response.body, symbolize_names: true)
+  #           }
+  #         }
+  #       end
+  #       run_test!
+  #     end
+  #   end
+  # end
+
+  path '/random_thoughts/{id}' do
+    parameter name: 'id', in: :path, type: :string, description: 'id'
+
+    get('show random_thought') do
+      consumes 'application/json'
+      produces 'application/json'
+
+      response(200, 'successful') do
+        let(:id) { create(:random_thought).id }
+        schema '$ref' => '#/components/schemas/random_thought'
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+
+        run_test!
+      end
+    end
+
+    # patch('update random_thought') do
+    #   response(200, 'successful') do
+    #     let(:id) { '123' }
+
+    #     after do |example|
+    #       example.metadata[:response][:content] = {
+    #         'application/json' => {
+    #           example: JSON.parse(response.body, symbolize_names: true)
+    #         }
+    #       }
+    #     end
+    #     run_test!
+    #   end
+    # end
+
+    # put('update random_thought') do
+    #   response(200, 'successful') do
+    #     let(:id) { '123' }
+
+    #     after do |example|
+    #       example.metadata[:response][:content] = {
+    #         'application/json' => {
+    #           example: JSON.parse(response.body, symbolize_names: true)
+    #         }
+    #       }
+    #     end
+    #     run_test!
+    #   end
+    # end
+
+    # delete('delete random_thought') do
+    #   response(200, 'successful') do
+    #     let(:id) { '123' }
+
+    #     after do |example|
+    #       example.metadata[:response][:content] = {
+    #         'application/json' => {
+    #           example: JSON.parse(response.body, symbolize_names: true)
+    #         }
+    #       }
+    #     end
+    #     run_test!
+    #   end
+    # end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -30,8 +30,25 @@ RSpec.configure do |config|
               default: 'www.example.com'
             }
           }
+        },
+        {
+          url: 'http://localhost:3000',
+          description: 'Local development'
         }
-      ]
+      ],
+      components: {
+        schemas: {
+          random_thought: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer' },
+              thought: { type: 'string' },
+              name: { type: 'string' }
+            },
+            required: %w[id thought name]
+          }
+        }
+      }
     }
   }
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,45 @@
+---
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/random_thoughts/{id}":
+    parameters:
+    - name: id
+      in: path
+      description: id
+      required: true
+      schema:
+        type: string
+    get:
+      summary: show random_thought
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/random_thought"
+servers:
+- url: https://{defaultHost}
+  variables:
+    defaultHost:
+      default: www.example.com
+- url: http://localhost:3000
+  description: Local development
+components:
+  schemas:
+    random_thought:
+      type: object
+      properties:
+        id:
+          type: integer
+        thought:
+          type: string
+        name:
+          type: string
+      required:
+      - id
+      - thought
+      - name


### PR DESCRIPTION
# What

This changeset adds the ability to retrieve an existing RandomThought in JSON format from the `get /random_thoughts/{id}` endpoint.

Specifically...
- Adds RandomThought resource
- Adds Swagger test for get /random_thoughts/{id}
- Adds functional tests for get /random_thoughts/{id}
- Adds random_thoughts_controller#show
- Adds Factory for RandomThought
- Adds Faker gem for test data
- Updates README

# Why

This allows the user of the API to retrieve an existing RandomThought.

# Change Impact Analysis and Testing
This is the first real functionality for this application so there is no risk of regressions from this changeset.

New functionality is verified by...
- [x] Running new automated tests
- [x] Manual exploratory testing using Swagger UI

Updated documentation is verified by...
- [x] Manual inspection of README