### PR TITLE
Add Ability to Create RandomThought (post /random_thoughts/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ This API contains the following endpoints...
 * **Show** random thought {id}: `get /random_thoughts/{id}`
   (e.g. http://localhost:3000/random_thoughts/1)
 
+* **Create** random thought: `post /random_thoughts/`
+  with Request Body...
+  ```json
+  {
+    "thought": "string",
+    "name": "string"
+  }
+  ```
+
 ## Development
 This project can be developed using the supplied basic, container-based
 development environment which includes `vim`, `git`, `curl`, and `psql`.

--- a/app/controllers/random_thoughts_controller.rb
+++ b/app/controllers/random_thoughts_controller.rb
@@ -4,6 +4,21 @@
 class RandomThoughtsController < ApplicationController
   def show
     @random_thought = RandomThought.find(params[:id])
-    render json: @random_thought, only: %i[id thought name]
+    render_random_thought(200)
+  end
+
+  def create
+    @random_thought = RandomThought.create!(random_thought_params)
+    render_random_thought(201)
+  end
+
+  private
+
+  def random_thought_params
+    params.required(:random_thought).permit(:thought, :name)
+  end
+
+  def render_random_thought(status)
+    render json: @random_thought, only: %i[id thought name], status:
   end
 end

--- a/app/lib/error/error_handler.rb
+++ b/app/lib/error/error_handler.rb
@@ -17,6 +17,11 @@ module Error
         rescue_from ActiveRecord::RecordNotFound do |e|
           render_response(404, :not_found, e.to_s)
         end
+
+        rescue_from ActionController::ParameterMissing,
+                    ActionDispatch::Http::Parameters::ParseError do |e|
+          render_response(400, :bad_request, e.to_s)
+        end
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :random_thoughts, only: [:show]
+  resources :random_thoughts, only: [:show, :create]
   mount Rswag::Api::Engine => '/api-docs'
   mount Rswag::Ui::Engine => '/api-docs'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/spec/requests/create_random_thought_spec.rb
+++ b/spec/requests/create_random_thought_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../support/shared_examples/random_thought_response'
+
+RSpec.describe 'post /random_thoughts/' do
+  context 'when valid create request' do
+    let(:random_thought) { build(:random_thought) }
+
+    before do |example|
+      post_random_thought(random_thought) unless example.metadata[:skip_before]
+    end
+
+    it 'creates a new RandomThought', :skip_before do
+      expect do
+        post_random_thought(random_thought)
+      end.to change(RandomThought, :count).by(1)
+    end
+
+    it_behaves_like 'random thought response'
+  end
+
+  context 'when parameters are missing in create request' do
+    before do |example|
+      post_empty_request unless example.metadata[:skip_before]
+    end
+
+    it 'does not create a new RandomThought', :skip_before do
+      expect do
+        post_empty_request
+      end.not_to change(RandomThought, :count)
+    end
+
+    it 'returns "status": 400' do
+      expect(json_body['status']).to be(400)
+    end
+
+    it 'returns "error": "bad_request"' do
+      expect(json_body['error']).to eql('bad_request')
+    end
+
+    it 'returns "message" indicating parameters are missing' do
+      expect(json_body['message']).to include('param is missing or the value is empty')
+    end
+  end
+
+  # TODO: Testing invalid json does not seem to be possible
+
+  private
+
+  def post_random_thought(random_thought)
+    post random_thoughts_path, params: {
+      random_thought: {
+        thought: random_thought.thought,
+        name: random_thought.name
+      }
+    }
+  end
+
+  def post_empty_request
+    post random_thoughts_path, params: {}
+  end
+end

--- a/spec/requests/get_random_thought_spec.rb
+++ b/spec/requests/get_random_thought_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../support/shared_examples/random_thought_response'
 
 RSpec.describe 'get /random_thoughts/{id}' do
   context 'when {id} exists' do
@@ -14,13 +15,7 @@ RSpec.describe 'get /random_thoughts/{id}' do
       expect(json_body['id']).to eql(random_thought.id)
     end
 
-    it 'returns "thought": thought' do
-      expect(json_body['thought']).to eql(random_thought.thought)
-    end
-
-    it 'returns "name": name' do
-      expect(json_body['name']).to eql(random_thought.name)
-    end
+    it_behaves_like 'random thought response'
   end
 
   context 'when {id} does not exists' do

--- a/spec/requests/random_thoughts_spec.rb
+++ b/spec/requests/random_thoughts_spec.rb
@@ -4,7 +4,7 @@ require 'swagger_helper'
 
 RSpec.describe 'random_thoughts', type: :request do
 
-  # path '/random_thoughts' do
+  path '/random_thoughts' do
 
     # get('list random_thoughts') do
     #   response(200, 'successful') do
@@ -20,20 +20,46 @@ RSpec.describe 'random_thoughts', type: :request do
     #   end
     # end
 
-  #   post('create random_thought') do
-  #     response(200, 'successful') do
+    post('create random_thought') do
+      consumes 'application/json'
+      produces 'application/json'
+      parameter name: :random_thought,
+                in: :body,
+                schema: { '$ref' => '#/components/schemas/new_random_thought' }
 
-  #       after do |example|
-  #         example.metadata[:response][:content] = {
-  #           'application/json' => {
-  #             example: JSON.parse(response.body, symbolize_names: true)
-  #           }
-  #         }
-  #       end
-  #       run_test!
-  #     end
-  #   end
-  # end
+      response(201, 'created') do
+        let(:random_thought) { build(:random_thought) }
+        schema '$ref' => '#/components/schemas/random_thought'
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+
+        run_test!
+      end
+
+      response(400, 'bad request') do
+        let(:random_thought) { {} }
+        schema '$ref' => '#/components/schemas/error'
+        example 'application/json', :empty_request, {
+          status: 400,
+          error: 'bad_request',
+          message: 'param is missing or the value is empty:...'
+        }
+        example 'application/json', :invalid_request, {
+          status: 400,
+          error: 'bad_request',
+          message: 'Error occurred while parsing request parameters'
+        }
+
+        run_test!
+      end
+    end
+  end
 
   path '/random_thoughts/{id}' do
     parameter name: 'id', in: :path, type: :string, description: 'id'

--- a/spec/support/shared_examples/random_thought_response.rb
+++ b/spec/support/shared_examples/random_thought_response.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'random thought response' do
+  it 'returns integer "id":' do
+    expect(json_body['id']).to be_a(Integer)
+  end
+
+  it 'returns "thought": thought' do
+    expect(json_body['thought']).to eql(random_thought.thought)
+  end
+
+  it 'returns "name": name' do
+    expect(json_body['name']).to eql(random_thought.name)
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -38,6 +38,14 @@ RSpec.configure do |config|
       ],
       components: {
         schemas: {
+          new_random_thought: {
+            type: 'object',
+            properties: {
+              thought: { type: 'string' },
+              name: { type: 'string' }
+            },
+            required: %w[thought name]
+          },
           random_thought: {
             type: 'object',
             properties: {

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -4,6 +4,39 @@ info:
   title: API V1
   version: v1
 paths:
+  "/random_thoughts":
+    post:
+      summary: create random_thought
+      parameters: []
+      responses:
+        '201':
+          description: created
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/random_thought"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              examples:
+                empty_request:
+                  value:
+                    status: 400
+                    error: bad_request
+                    message: param is missing or the value is empty:...
+                invalid_request:
+                  value:
+                    status: 400
+                    error: bad_request
+                    message: Error occurred while parsing request parameters
+              schema:
+                "$ref": "#/components/schemas/error"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/new_random_thought"
   "/random_thoughts/{id}":
     parameters:
     - name: id
@@ -54,6 +87,16 @@ servers:
   description: Local development
 components:
   schemas:
+    new_random_thought:
+      type: object
+      properties:
+        thought:
+          type: string
+        name:
+          type: string
+      required:
+      - thought
+      - name
     random_thought:
       type: object
       properties:


### PR DESCRIPTION
# What

This functional additive changeset implements creating a new random_thought through the `post /random_thoughts/` route and the `random_thoughts_controller#create` action.  It also includes the tests, specifically
  - Swagger test for successful creation (201)
  - Swagger test for bad request (400)
  - Skipped Swagger test for default errors (500)
  - Functional request tests for post/create (success and empty request body)
  - Refactoring of code under development and test
  - Regenerate Swagger File
  - Update README with new endpoint

# Why

Provides the user the ability to create random_thoughts and the tests
to maintain this ability.

# Change Impact Analysis and Testing

This changeset adds new functionality to create random_thought...
- [x] Develop and Run new request tests to ensure new functionality works as intended...
  - [x] Creates new random_request
  - [x] Returns 201 response with `random_thought` schema with correct values
  - [x] Handles bad requests returning 400 response
- [x] Manually inspect and test updated Swagger File using Swagger UI
- [x] Manually test (with Swagger UI) malformed request body returns 400 and proper error message (unable to test this in automated tests)

This changeset refactors existing code
- [x] Ensure any refactored code is under test
- [x] Run existing tests to verify that there are no regressions
- [x] Manually inspect and test updated Swagger File using Swagger UI

This changeset updates README
- [x] README manually inspected

