### PR TITLE
Add Ability to Get All RandomThoughts (get /random_thoughts) With Pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "pg", "~> 1.1"
 gem "puma", "~> 5.0"
 
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
-# gem "jbuilder"
+gem "jbuilder"
 
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
@@ -47,15 +47,18 @@ group :development do
 end
 
 # --- CUSTOM GEMS ---
-   # Add Swagger/OpenAPI endpoints to all environments
-   gem 'rswag-api'
-   gem 'rswag-ui'
+# Pagination
+gem 'kaminari'
 
-   # Development and Test add RSpec, FactoryBot, and Swagger Specs
-   group :development, :test do
-     gem 'factory_bot_rails'
-     gem 'faker'
-     gem 'rspec-rails'
-     # Swagger specs
-     gem 'rswag-specs'
-   end
+# Add Swagger/OpenAPI endpoints to all environments
+gem 'rswag-api'
+gem 'rswag-ui'
+
+# Development and Test add RSpec, FactoryBot, and Swagger Specs
+group :development, :test do
+  gem 'factory_bot_rails'
+  gem 'faker'
+  gem 'rspec-rails'
+  # Swagger specs
+  gem 'rswag-specs'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,8 +88,23 @@ GEM
       activesupport (>= 5.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    jbuilder (2.11.5)
+      actionview (>= 5.0.0)
+      activesupport (>= 5.0.0)
     json-schema (3.0.0)
       addressable (>= 2.8)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -194,6 +209,8 @@ DEPENDENCIES
   debug
   factory_bot_rails
   faker
+  jbuilder
+  kaminari
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.4)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ mounted into the container.
 ## API Endpoints
 This API contains the following endpoints...
 
+* **Index** all random thoughts: `get /random_thoughts?page={num}`
+  (e.g. http://localhost:3000/random_thoughts?page=2)
+
 * **Show** random thought {id}: `get /random_thoughts/{id}`
   (e.g. http://localhost:3000/random_thoughts/1)
 

--- a/app/controllers/random_thoughts_controller.rb
+++ b/app/controllers/random_thoughts_controller.rb
@@ -2,23 +2,23 @@
 
 # Implements CRUD operations for RandomThought
 class RandomThoughtsController < ApplicationController
+  def index
+    @random_thoughts = RandomThought.page(params[:page])
+  end
+
   def show
     @random_thought = RandomThought.find(params[:id])
-    render_random_thought(200)
   end
 
   def create
     @random_thought = RandomThought.create!(random_thought_params)
-    render_random_thought(201)
+    # FYI: render 'show' renders random_thoughts/show.json.jbuilder
+    render 'show', status: :created
   end
 
   private
 
   def random_thought_params
     params.required(:random_thought).permit(:thought, :name)
-  end
-
-  def render_random_thought(status)
-    render json: @random_thought, only: %i[id thought name], status:
   end
 end

--- a/app/models/random_thought.rb
+++ b/app/models/random_thought.rb
@@ -1,2 +1,6 @@
+# frozen_string_literal: true
+
+# Represents someone's random thought
 class RandomThought < ApplicationRecord
+  default_scope -> { order(created_at: :desc) }
 end

--- a/app/views/random_thoughts/_random_thought.json.jbuilder
+++ b/app/views/random_thoughts/_random_thought.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.call(random_thought, :id, :thought, :name)

--- a/app/views/random_thoughts/index.json.jbuilder
+++ b/app/views/random_thoughts/index.json.jbuilder
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+json.data @random_thoughts, partial: 'random_thought', as: :random_thought
+
+json.meta do
+  json.current_page @random_thoughts.current_page
+  json.next_page @random_thoughts.next_page
+  json.prev_page @random_thoughts.prev_page
+  json.total_pages @random_thoughts.total_pages
+  json.total_count RandomThought.count
+end

--- a/app/views/random_thoughts/show.json.jbuilder
+++ b/app/views/random_thoughts/show.json.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! @random_thought, partial: 'random_thought', as: :random_thought

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :random_thoughts, only: [:show, :create]
+  resources :random_thoughts, only: %i[index show create], defaults: { format: 'json' }
   mount Rswag::Api::Engine => '/api-docs'
   mount Rswag::Ui::Engine => '/api-docs'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20230131170025_add_index_to_random_thoughts.rb
+++ b/db/migrate/20230131170025_add_index_to_random_thoughts.rb
@@ -1,0 +1,5 @@
+class AddIndexToRandomThoughts < ActiveRecord::Migration[7.0]
+  def change
+    add_index :random_thoughts, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_24_225128) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_31_170025) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_24_225128) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_random_thoughts_on_created_at"
   end
 
 end

--- a/spec/models/random_thought_spec.rb
+++ b/spec/models/random_thought_spec.rb
@@ -1,5 +1,11 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe RandomThought, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe RandomThought do
+  it 'returns most recent first' do
+    create_list(:random_thought, 20)
+    most_recent = create(:random_thought)
+    expect(described_class.first).to eql(most_recent)
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,7 +9,9 @@ require 'rspec/rails'
 
 # --- CUSTOM ---
 require_relative 'support/factory_bot'
+
 require_relative 'support/api_helper'
+require_relative 'support/matchers/be_random_thought_json'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/requests/get_random_thoughts_spec.rb
+++ b/spec/requests/get_random_thoughts_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'get /random_thoughts/' do
+  shared_context 'when there are at least three pages' do
+    let(:pages) { 3 }
+    let(:per_page) { RandomThought.page.limit_value }
+    let(:num_random_thoughts) { (per_page * (pages - 1)) + 1 }
+
+    before do
+      create_list(:random_thought, num_random_thoughts)
+    end
+  end
+  context 'when there are random_thoughts' do
+    let(:page) { rand(1..pages) }
+
+    include_context 'when there are at least three pages'
+
+    before do
+      get random_thoughts_path({ page: })
+    end
+
+    describe 'returned "data" body' do
+      it 'contains all correct random thought "id"s for page' do
+        all_returned = data_body
+        RandomThought.page(page).each do |random_thought|
+          returned = all_returned.shift
+          expect(returned['id']).to be(random_thought.id)
+        end
+      end
+
+      it 'contains all correct random thoughts for page' do
+        all_returned = data_body
+        RandomThought.page(page).each do |random_thought|
+          returned = all_returned.shift
+          expect(returned).to be_random_thought_json(random_thought)
+        end
+      end
+    end
+
+    describe 'returned "meta" body' do
+      it 'contains requested page in "current_page"' do
+        expect(metadata_body['current_page']).to eql(page)
+      end
+
+      it 'contains correct number in "total_pages"' do
+        expect(metadata_body['total_pages']).to be(pages)
+      end
+
+      it 'contains correct total in "total_count"' do
+        expect(metadata_body['total_count']).to be(num_random_thoughts)
+      end
+    end
+  end
+
+  context 'when first page requested' do
+    include_context 'when there are at least three pages'
+
+    before do
+      get random_thoughts_path({ page: 1 })
+    end
+
+    describe 'returned "meta" body' do
+      it 'contains "prev_page": nil' do
+        expect(metadata_body['prev_page']).to be_nil
+      end
+    end
+  end
+
+  context 'when last page requested' do
+    include_context 'when there are at least three pages'
+
+    before do
+      get random_thoughts_path({ page: pages })
+    end
+
+    describe 'returned "meta" body' do
+      it 'contains "next_page": nil' do
+        expect(metadata_body['next_page']).to be_nil
+      end
+    end
+  end
+
+  context 'when page in middle requested' do
+    let(:middle_page) { 2 }
+
+    include_context 'when there are at least three pages'
+
+    before do
+      get random_thoughts_path({ page: middle_page })
+    end
+
+    describe 'returned "meta" body' do
+      it 'contains correct "next_page"' do
+        expect(metadata_body['next_page']).to be(middle_page + 1)
+      end
+
+      it 'contains correct "prev_page"' do
+        expect(metadata_body['prev_page']).to be(middle_page - 1)
+      end
+    end
+  end
+
+  context 'when there are no random thoughts' do
+    let(:page) { 1 }
+
+    before do
+      get random_thoughts_path({ page: })
+    end
+
+    describe 'returned "data" body' do
+      it 'contains [] (empty array)' do
+        expect(data_body).to eql([])
+      end
+    end
+
+    describe 'returned "meta" body' do
+      it 'contains requested page in "current_page"' do
+        expect(metadata_body['current_page']).to eql(page)
+      end
+
+      it 'contains "next_page": nil' do
+        expect(metadata_body['next_page']).to be_nil
+      end
+
+      it 'contains "prev_page": nil' do
+        expect(metadata_body['prev_page']).to be_nil
+      end
+
+      it 'contains "total_pages": 0' do
+        expect(metadata_body['total_pages']).to be(0)
+      end
+
+      it 'contains "total_count": 0' do
+        expect(metadata_body['total_count']).to be(0)
+      end
+    end
+  end
+
+  private
+
+  def data_body
+    json_body['data']
+  end
+
+  def metadata_body
+    json_body['meta']
+  end
+end

--- a/spec/requests/random_thoughts_spec.rb
+++ b/spec/requests/random_thoughts_spec.rb
@@ -3,22 +3,32 @@
 require 'swagger_helper'
 
 RSpec.describe 'random_thoughts', type: :request do
-
   path '/random_thoughts' do
+    get('list random_thoughts') do
+      consumes 'application/json'
+      produces 'application/json'
+      parameter name: 'page',
+                in: :query,
+                type: :integer,
+                description: 'page number',
+                required: false
 
-    # get('list random_thoughts') do
-    #   response(200, 'successful') do
+      response(200, 'successful') do
+        let!(:random_thought) { create(:random_thought) }
 
-    #     after do |example|
-    #       example.metadata[:response][:content] = {
-    #         'application/json' => {
-    #           example: JSON.parse(response.body, symbolize_names: true)
-    #         }
-    #       }
-    #     end
-    #     run_test!
-    #   end
-    # end
+        schema '$ref' => '#/components/schemas/paginated_random_thoughts'
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+
+        run_test!
+      end
+    end
 
     post('create random_thought') do
       consumes 'application/json'

--- a/spec/support/matchers/be_random_thought_json.rb
+++ b/spec/support/matchers/be_random_thought_json.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Custom RSpec Matcher to match critical
+# attribute values to be a random_thought
+# JSON response
+module BeRandomThoughtJson
+  class BeRandomThoughtJson
+    def initialize(expected_thought)
+      @expected_thought = expected_thought
+    end
+
+    def matches?(actual)
+      @actual = actual
+
+      @actual['thought'] == @expected_thought.thought &&
+        @actual['name'] == @expected_thought.name
+    end
+
+    def failure_message
+      "expected that actual: #{pretty(@actual)} would match " \
+        "expected: #{pretty(matched_expected)}"
+    end
+
+    def failure_message_when_negated
+      "expected that actual: #{pretty(@actual)} would not match " \
+        "expected: #{pretty(matched_expected)}"
+    end
+
+    private
+
+    def pretty(json)
+      JSON.pretty_generate(json)
+    end
+
+    def matched_expected
+      @expected_thought.attributes.slice('id', 'thought', 'name')
+    end
+  end
+
+  def be_random_thought_json(expected_thought)
+    BeRandomThoughtJson.new(expected_thought)
+  end
+end
+
+# Include the custom matcher in RSpec
+RSpec.configure do |config|
+  config.include BeRandomThoughtJson
+end

--- a/spec/support/shared_examples/random_thought_response.rb
+++ b/spec/support/shared_examples/random_thought_response.rb
@@ -1,15 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'random thought response' do
-  it 'returns integer "id":' do
-    expect(json_body['id']).to be_a(Integer)
-  end
-
-  it 'returns "thought": thought' do
-    expect(json_body['thought']).to eql(random_thought.thought)
-  end
-
-  it 'returns "name": name' do
-    expect(json_body['name']).to eql(random_thought.name)
+  it 'returns random_thought json with correct values' do
+    expect(json_body).to be_random_thought_json(random_thought)
   end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -55,6 +55,34 @@ RSpec.configure do |config|
             },
             required: %w[id thought name]
           },
+          paginated_random_thoughts: {
+            type: 'object',
+            properties: {
+              data: {
+                type: :array,
+                items: { '$ref' => '#/components/schemas/random_thought' }
+              },
+              meta: {
+                '$ref' => '#/components/schemas/pagination'
+              }
+            },
+            required: %w[data meta]
+          },
+          pagination: {
+            type: 'object',
+            properties: {
+              current_page: { type: 'integer' },
+              next_page: { type: 'integer', nullable: true },
+              prev_page: { type: 'integer', nullable: true },
+              total_pages: { type: 'integer' },
+              total_count: { type: 'integer' }
+            },
+            required: %w[current_page
+                         next_page
+                         prev_page
+                         total_pages
+                         total_count]
+          },
           error: {
             type: 'object',
             properties: {

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -5,6 +5,22 @@ info:
   version: v1
 paths:
   "/random_thoughts":
+    get:
+      summary: list random_thoughts
+      parameters:
+      - name: page
+        in: query
+        description: page number
+        required: false
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/paginated_random_thoughts"
     post:
       summary: create random_thought
       parameters: []
@@ -110,6 +126,39 @@ components:
       - id
       - thought
       - name
+    paginated_random_thoughts:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/random_thought"
+        meta:
+          "$ref": "#/components/schemas/pagination"
+      required:
+      - data
+      - meta
+    pagination:
+      type: object
+      properties:
+        current_page:
+          type: integer
+        next_page:
+          type: integer
+          nullable: true
+        prev_page:
+          type: integer
+          nullable: true
+        total_pages:
+          type: integer
+        total_count:
+          type: integer
+      required:
+      - current_page
+      - next_page
+      - prev_page
+      - total_pages
+      - total_count
     error:
       type: object
       properties:


### PR DESCRIPTION
# What

This changeset adds new functionality to get all RandomThoughts with pagination through the new API endpoint`get /random_thoughts/` with the `page` query parameter (`get /random_thoughts?page=23`).

Specifically...
* Adds `kaminari` gem for pagination
* Adds `jbuilder` gem for building JSON responses
* Adds default scope of latest first for RandomThoughts
* Adds  index for RandomThought `created_at`
* Adds `random_thoughts_controller#index`
* Adds Swagger File specification (tests) for successful (200)`get /random_thoughts/`
* Adds functional tests for `get /random_thoughts/`
* Adds custom RSpec matcher to verify correct RandomThought response JSON
* Refactoring of code under development and test
* Update README with new endpoint

# Why

This adds ability and Swagger specification to get all created RandomThoughts in a paginated manner and ensure this ability throughout changes with automated tests.

# Change Impact Analysis and Testing


New functionality is verified by...
- [x] Running new automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Refactored existing functionality is verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Updated documentation is verified by...
- [x] Manual inspection of README
