### PR TITLE
Fix On-PR Workflow to Use APP_IMAGE So It Uses Correct Image

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: dockercomposerun tests on development environment
-        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun ./script/run tests"
+        run: "APP_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun ./script/run tests"
 
   vet-swagger-file-currency:
     needs: [pr-norm-branch, build-and-push-branch-devenv]
@@ -51,6 +51,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: dockercomposerun swaggerize on development environment
-        run: "BROWSERTESTS_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun ./script/run swaggerize"
+        run: "APP_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun ./script/run swaggerize"
       - name: git diff Swagger File(s) to ensure no changes
         run: git diff --exit-code swagger


### PR DESCRIPTION
# What

This changeset fixes a copy/paste defect where the On-Pull Request (PR) workflow was not actually
using the image built in the workflow.  Instead the `vet-swagger-file-currency` and `vet-unit-tests` jobs were using the default development environment image.  This bug manifests when the `Gemfile` has new gems that are not in that default development environment image.

# Why

This effort resolves a defect and ensures that the image for the commit is being used for vetting.

# Change Impact Analysis and Testing

This changeset was successfully tested in the pull request where the defect was found and that workflow file was copied to this branch.
