### PR TITLE
Add Ability to Update RandomThought (patch /random_thoughts/{id})

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ This API contains the following endpoints...
   }
   ```
 
+* **Update** random thought {id}: `patch /random_thoughts/{id}`
+  with Request Body...
+  ```json
+  {
+    "thought": "string",
+    "name": "string"
+  }
+  ```
+
 ## Development
 This project can be developed using the supplied basic, container-based
 development environment which includes `vim`, `git`, `curl`, and `psql`.

--- a/app/controllers/random_thoughts_controller.rb
+++ b/app/controllers/random_thoughts_controller.rb
@@ -2,12 +2,14 @@
 
 # Implements CRUD operations for RandomThought
 class RandomThoughtsController < ApplicationController
+  before_action :find_random_thought, only: %i[show update]
+
   def index
     @random_thoughts = RandomThought.page(params[:page])
   end
 
   def show
-    @random_thought = RandomThought.find(params[:id])
+    # before_action and show view
   end
 
   def create
@@ -16,9 +18,18 @@ class RandomThoughtsController < ApplicationController
     render 'show', status: :created
   end
 
+  def update
+    @random_thought.update(random_thought_params)
+    render 'show', status: :ok
+  end
+
   private
 
   def random_thought_params
     params.required(:random_thought).permit(:thought, :name)
+  end
+
+  def find_random_thought
+    @random_thought = RandomThought.find(params[:id])
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  resources :random_thoughts, only: %i[index show create], defaults: { format: 'json' }
+  resources :random_thoughts,
+            only: %i[index show create update],
+            defaults: { format: 'json' }
   mount Rswag::Api::Engine => '/api-docs'
   mount Rswag::Ui::Engine => '/api-docs'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/spec/requests/get_random_thought_spec.rb
+++ b/spec/requests/get_random_thought_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../support/shared_examples/not_found_response'
 require_relative '../support/shared_examples/random_thought_response'
 
 RSpec.describe 'get /random_thoughts/{id}' do
@@ -18,23 +19,13 @@ RSpec.describe 'get /random_thoughts/{id}' do
     it_behaves_like 'random thought response'
   end
 
-  context 'when {id} does not exists' do
+  context 'when {id} does not exist' do
     let(:not_random_thought) { build(:random_thought).id = 0 }
 
     before do
       get random_thought_path(not_random_thought)
     end
 
-    it 'returns "status": 404' do
-      expect(json_body['status']).to be(404)
-    end
-
-    it 'returns "error": "not_found"' do
-      expect(json_body['error']).to eql('not_found')
-    end
-
-    it 'returns "message": ...' do
-      expect(json_body['message']).to include("Couldn't find ")
-    end
+    it_behaves_like 'not_found response'
   end
 end

--- a/spec/requests/random_thoughts_spec.rb
+++ b/spec/requests/random_thoughts_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe 'random_thoughts', type: :request do
 
       response(201, 'created') do
         let(:random_thought) { build(:random_thought) }
+
         schema '$ref' => '#/components/schemas/random_thought'
 
         after do |example|
@@ -54,6 +55,7 @@ RSpec.describe 'random_thoughts', type: :request do
 
       response(400, 'bad request') do
         let(:random_thought) { {} }
+
         schema '$ref' => '#/components/schemas/error'
         example 'application/json', :empty_request, {
           status: 400,
@@ -80,6 +82,7 @@ RSpec.describe 'random_thoughts', type: :request do
 
       response(200, 'successful') do
         let(:id) { create(:random_thought).id }
+
         schema '$ref' => '#/components/schemas/random_thought'
 
         after do |example|
@@ -95,6 +98,7 @@ RSpec.describe 'random_thoughts', type: :request do
 
       response(404, 'not found') do
         let(:id) { 0 }
+
         schema '$ref' => '#/components/schemas/error'
         example 'application/json', :not_found, {
           status: 404,
@@ -109,6 +113,7 @@ RSpec.describe 'random_thoughts', type: :request do
       # Unable to produce the test conditions for 500
       response(500, 'internal server error') do
         let(:id) { create(:random_thought).id }
+
         schema '$ref' => '#/components/schemas/error'
         example 'application/json', :internal_server_error, {
           status: 500,
@@ -128,20 +133,44 @@ RSpec.describe 'random_thoughts', type: :request do
       end
     end
 
-    # patch('update random_thought') do
-    #   response(200, 'successful') do
-    #     let(:id) { '123' }
+    patch('update random_thought') do
+      consumes 'application/json'
+      produces 'application/json'
+      parameter name: :update,
+                in: :body,
+                schema: { '$ref' => '#/components/schemas/update_random_thought' }
 
-    #     after do |example|
-    #       example.metadata[:response][:content] = {
-    #         'application/json' => {
-    #           example: JSON.parse(response.body, symbolize_names: true)
-    #         }
-    #       }
-    #     end
-    #     run_test!
-    #   end
-    # end
+      response(200, 'successful') do
+        let(:id) { create(:random_thought).id }
+        let(:update) { build(:random_thought, thought: 'new thought', name: 'new name') }
+
+        schema '$ref' => '#/components/schemas/random_thought'
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+
+        run_test!
+      end
+
+      response(404, 'not found') do
+        let(:id) { 0 }
+        let(:update) { build(:random_thought) }
+
+        schema '$ref' => '#/components/schemas/error'
+        example 'application/json', :not_found, {
+          status: 404,
+          error: 'not_found',
+          message: "Couldn't find RandomThought with 'id'=??"
+        }
+
+        run_test!
+      end
+    end
 
     # put('update random_thought') do
     #   response(200, 'successful') do

--- a/spec/requests/update_random_thought_spec.rb
+++ b/spec/requests/update_random_thought_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../support/shared_examples/not_found_response'
+
+RSpec.describe 'patch /random_thoughts/{id}' do
+  context 'when {id} exists' do
+    let(:random_thought) { create(:random_thought) }
+    let(:new_thought) { 'I like turtles' }
+    let(:new_name) { ' Jonathan "Zombie Kid" Ware' }
+
+    it 'updates thought when supplied' do
+      patch_random_thought(random_thought, new_thought:)
+      expect(random_thought.reload.thought).to eql(new_thought)
+    end
+
+    it 'updates name when supplied' do
+      patch_random_thought(random_thought, new_name:)
+      expect(random_thought.reload.name).to eql(new_name)
+    end
+
+    it 'returns "id": id' do
+      patch_random_thought(random_thought, new_thought:, new_name:)
+      expect(json_body['id']).to eql(random_thought.id)
+    end
+
+    it 'returns updated random_thought JSON' do
+      patch_random_thought(random_thought, new_thought:, new_name:)
+      expect(json_body).to be_random_thought_json(random_thought.reload)
+    end
+  end
+
+  context 'when {id} does not exist' do
+    let(:does_not_exist) { build(:random_thought).id = 0 }
+
+    before do
+      patch_random_thought(does_not_exist, new_thought: '...', new_name: '...')
+    end
+
+    it_behaves_like 'not_found response'
+  end
+
+  private
+
+  def patch_random_thought(random_thought, new_thought: false, new_name: false)
+    update = {}
+    update['thought'] = new_thought if new_thought
+    update['name'] = new_name if new_name
+    patch random_thought_path(random_thought), params: update, as: :json
+  end
+end

--- a/spec/support/shared_examples/not_found_response.rb
+++ b/spec/support/shared_examples/not_found_response.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'not_found response' do
+  it 'returns "status": 404' do
+    expect(json_body['status']).to be(404)
+  end
+
+  it 'returns "error": "not_found"' do
+    expect(json_body['error']).to eql('not_found')
+  end
+
+  it 'returns "message": ...' do
+    expect(json_body['message']).to include("Couldn't find ")
+  end
+end

--- a/spec/support/shared_examples/random_thought_response.rb
+++ b/spec/support/shared_examples/random_thought_response.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'random thought response' do
-  it 'returns random_thought json with correct values' do
+  it 'returns random_thought JSON with correct values' do
     expect(json_body).to be_random_thought_json(random_thought)
   end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -55,6 +55,13 @@ RSpec.configure do |config|
             },
             required: %w[id thought name]
           },
+          update_random_thought: {
+            type: 'object',
+            properties: {
+              thought: { type: 'string' },
+              name: { type: 'string' }
+            }
+          },
           paginated_random_thoughts: {
             type: 'object',
             properties: {

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -94,6 +94,33 @@ paths:
                     message: "..."
               schema:
                 "$ref": "#/components/schemas/error"
+    patch:
+      summary: update random_thought
+      parameters: []
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/random_thought"
+        '404':
+          description: not found
+          content:
+            application/json:
+              examples:
+                not_found:
+                  value:
+                    status: 404
+                    error: not_found
+                    message: Couldn't find RandomThought with 'id'=??
+              schema:
+                "$ref": "#/components/schemas/error"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/update_random_thought"
 servers:
 - url: https://{defaultHost}
   variables:
@@ -126,6 +153,13 @@ components:
       - id
       - thought
       - name
+    update_random_thought:
+      type: object
+      properties:
+        thought:
+          type: string
+        name:
+          type: string
     paginated_random_thoughts:
       type: object
       properties:


### PR DESCRIPTION
# What

This changeset adds new functionality to update a RandomThought through the new API endpoint`patch /random_thoughts/{id}`.

Specifically...
* Adds `random_thoughts_controller#update`
* Adds Swagger File specification (tests) for `patch /random_thoughts/`
  * 200 success
  * 404 id not found
* Adds functional tests for `patch /random_thoughts/`
* Refactoring of code under development and test
* Update README with new endpoint


# Why

This adds ability and Swagger specification to update a created RandomThought and ensure this ability throughout changes with automated tests.

# Change Impact Analysis and Testing

New functionality is verified by...
- [x] Running new automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Refactored existing functionality is verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Updated documentation is verified by...
- [x] Manual inspection of README
