### PR TITLE
Add Ability to Delete RandomThought (delete /random_thoughts/{id})

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ This API contains the following endpoints...
   }
   ```
 
+* **Delete** random thought {id}: `delete /random_thoughts/{id}`
+
 ## Development
 This project can be developed using the supplied basic, container-based
 development environment which includes `vim`, `git`, `curl`, and `psql`.

--- a/app/controllers/random_thoughts_controller.rb
+++ b/app/controllers/random_thoughts_controller.rb
@@ -2,7 +2,7 @@
 
 # Implements CRUD operations for RandomThought
 class RandomThoughtsController < ApplicationController
-  before_action :find_random_thought, only: %i[show update]
+  before_action :find_random_thought, only: %i[show update destroy]
 
   def index
     @random_thoughts = RandomThought.page(params[:page])
@@ -14,13 +14,17 @@ class RandomThoughtsController < ApplicationController
 
   def create
     @random_thought = RandomThought.create!(random_thought_params)
-    # FYI: render 'show' renders random_thoughts/show.json.jbuilder
-    render 'show', status: :created
+    render_random_thought_response(:created)
   end
 
   def update
-    @random_thought.update(random_thought_params)
-    render 'show', status: :ok
+    @random_thought.update!(random_thought_params)
+    render_random_thought_response(:ok)
+  end
+
+  def destroy
+    @random_thought.destroy!
+    render_random_thought_response(:ok)
   end
 
   private
@@ -31,5 +35,10 @@ class RandomThoughtsController < ApplicationController
 
   def find_random_thought
     @random_thought = RandomThought.find(params[:id])
+  end
+
+  def render_random_thought_response(status)
+    # FYI: render 'show' renders random_thoughts/show.json.jbuilder
+    render 'show', status:
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,6 @@
 Rails.application.routes.draw do
-  resources :random_thoughts,
-            only: %i[index show create update],
-            defaults: { format: 'json' }
+  resources :random_thoughts, defaults: { format: 'json' }
+
   mount Rswag::Api::Engine => '/api-docs'
   mount Rswag::Ui::Engine => '/api-docs'
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
 end

--- a/spec/requests/delete_random_thought_spec.rb
+++ b/spec/requests/delete_random_thought_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../support/shared_examples/not_found_response'
+require_relative '../support/shared_examples/random_thought_response'
+
+RSpec.describe 'delete /random_thoughts/{id}' do
+  context 'when {id} exists' do
+    let!(:random_thought) { create(:random_thought) }
+
+    before do |example|
+      delete_random_thought(random_thought) unless example.metadata[:skip_before]
+    end
+
+    it 'deletes a RandomThought', :skip_before do
+      expect do
+        delete_random_thought(random_thought)
+      end.to change(RandomThought, :count).by(-1)
+    end
+
+    it 'deletes the random thought' do
+      expect(RandomThought.find_by(id: random_thought.id)).to be_nil
+    end
+
+    it 'returns "id": id' do
+      expect(json_body['id']).to eql(random_thought.id)
+    end
+
+    it_behaves_like 'random thought response'
+  end
+
+  context 'when {id} does not exist' do
+    let(:does_not_exist) { build(:random_thought).id = 0 }
+
+    before do
+      delete_random_thought(does_not_exist)
+    end
+
+    it_behaves_like 'not_found response'
+  end
+
+  private
+
+  def delete_random_thought(random_thought)
+    delete random_thought_path(random_thought)
+  end
+end

--- a/spec/requests/random_thoughts_spec.rb
+++ b/spec/requests/random_thoughts_spec.rb
@@ -172,34 +172,39 @@ RSpec.describe 'random_thoughts', type: :request do
       end
     end
 
-    # put('update random_thought') do
-    #   response(200, 'successful') do
-    #     let(:id) { '123' }
+    delete('delete random_thought') do
+      consumes 'application/json'
+      produces 'application/json'
 
-    #     after do |example|
-    #       example.metadata[:response][:content] = {
-    #         'application/json' => {
-    #           example: JSON.parse(response.body, symbolize_names: true)
-    #         }
-    #       }
-    #     end
-    #     run_test!
-    #   end
-    # end
+      response(200, 'successful') do
+        let(:id) { create(:random_thought).id }
 
-    # delete('delete random_thought') do
-    #   response(200, 'successful') do
-    #     let(:id) { '123' }
+        schema '$ref' => '#/components/schemas/random_thought'
 
-    #     after do |example|
-    #       example.metadata[:response][:content] = {
-    #         'application/json' => {
-    #           example: JSON.parse(response.body, symbolize_names: true)
-    #         }
-    #       }
-    #     end
-    #     run_test!
-    #   end
-    # end
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+
+        run_test!
+      end
+
+      response(404, 'not found') do
+        let(:id) { 0 }
+        let(:update) { build(:random_thought) }
+
+        schema '$ref' => '#/components/schemas/error'
+        example 'application/json', :not_found, {
+          status: 404,
+          error: 'not_found',
+          message: "Couldn't find RandomThought with 'id'=??"
+        }
+
+        run_test!
+      end
+    end
   end
 end

--- a/spec/requests/update_random_thought_spec.rb
+++ b/spec/requests/update_random_thought_spec.rb
@@ -5,9 +5,15 @@ require_relative '../support/shared_examples/not_found_response'
 
 RSpec.describe 'patch /random_thoughts/{id}' do
   context 'when {id} exists' do
-    let(:random_thought) { create(:random_thought) }
+    let!(:random_thought) { create(:random_thought) }
     let(:new_thought) { 'I like turtles' }
-    let(:new_name) { ' Jonathan "Zombie Kid" Ware' }
+    let(:new_name) { 'Jonathan "Zombie Kid" Ware' }
+
+    it 'does not change the number of RandomThoughts' do
+      expect do
+        patch_random_thought(random_thought, new_thought:, new_name:)
+      end.not_to change(RandomThought, :count)
+    end
 
     it 'updates thought when supplied' do
       patch_random_thought(random_thought, new_thought:)

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -121,6 +121,27 @@ paths:
           application/json:
             schema:
               "$ref": "#/components/schemas/update_random_thought"
+    delete:
+      summary: delete random_thought
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/random_thought"
+        '404':
+          description: not found
+          content:
+            application/json:
+              examples:
+                not_found:
+                  value:
+                    status: 404
+                    error: not_found
+                    message: Couldn't find RandomThought with 'id'=??
+              schema:
+                "$ref": "#/components/schemas/error"
 servers:
 - url: https://{defaultHost}
   variables:


### PR DESCRIPTION
# What

This changeset adds new functionality to delete an existing RandomThought through the new API endpoint`delete /random_thoughts/{id}`.

It also addresses an edge case with the update RandomThought by using `update!` instead of `update` so that an exception is thrown (instead of failing silently) if there is a fault during the database update of the record.

Specifically...
* Adds `random_thoughts_controller#destroy`
* Adds Swagger File specification (tests) for `delete /random_thoughts/`
  * 200
  * 404
* Adds functional tests for `delete /random_thoughts/`
* Refactoring of code under development and test
* Update README with new endpoint
* Fix `random_thoughts_controller#update` to use `update!`

# Why

This adds ability and Swagger specification to delete a created RandomThought and ensure this ability throughout changes with automated tests.

# Change Impact Analysis and Testing

New functionality is verified by...
- [ ] Running new automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Refactored existing functionality is verified by...
- [ ] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Updated documentation is verified by...
- [x] Manual inspection of README
