### PR TITLE
Reduce Maintenance Costs and Risk by Refactoring (DRY) random_thoughts Swagger Tests

### DIFF
--- a/spec/requests/random_thoughts_spec.rb
+++ b/spec/requests/random_thoughts_spec.rb
@@ -2,7 +2,32 @@
 
 require 'swagger_helper'
 
-RSpec.describe 'random_thoughts', type: :request do
+RSpec.describe 'random_thoughts' do
+  shared_context 'when not found' do
+    let(:id) { 0 }
+    schema '$ref' => '#/components/schemas/error'
+    example 'application/json', :not_found, {
+      status: 404,
+      error: 'not_found',
+      message: "Couldn't find RandomThought with 'id'=??"
+    }
+  end
+
+  shared_context 'when bad request' do
+    let(:bad_request) { {} }
+    schema '$ref' => '#/components/schemas/error'
+    example 'application/json', :empty_request, {
+      status: 400,
+      error: 'bad_request',
+      message: 'param is missing or the value is empty:...'
+    }
+    example 'application/json', :invalid_request, {
+      status: 400,
+      error: 'bad_request',
+      message: 'Error occurred while parsing request parameters'
+    }
+  end
+
   path '/random_thoughts' do
     get('list random_thoughts') do
       consumes 'application/json'
@@ -15,17 +40,7 @@ RSpec.describe 'random_thoughts', type: :request do
 
       response(200, 'successful') do
         let!(:random_thought) { create(:random_thought) }
-
         schema '$ref' => '#/components/schemas/paginated_random_thoughts'
-
-        after do |example|
-          example.metadata[:response][:content] = {
-            'application/json' => {
-              example: JSON.parse(response.body, symbolize_names: true)
-            }
-          }
-        end
-
         run_test!
       end
     end
@@ -39,35 +54,13 @@ RSpec.describe 'random_thoughts', type: :request do
 
       response(201, 'created') do
         let(:random_thought) { build(:random_thought) }
-
         schema '$ref' => '#/components/schemas/random_thought'
-
-        after do |example|
-          example.metadata[:response][:content] = {
-            'application/json' => {
-              example: JSON.parse(response.body, symbolize_names: true)
-            }
-          }
-        end
-
         run_test!
       end
 
       response(400, 'bad request') do
-        let(:random_thought) { {} }
-
-        schema '$ref' => '#/components/schemas/error'
-        example 'application/json', :empty_request, {
-          status: 400,
-          error: 'bad_request',
-          message: 'param is missing or the value is empty:...'
-        }
-        example 'application/json', :invalid_request, {
-          status: 400,
-          error: 'bad_request',
-          message: 'Error occurred while parsing request parameters'
-        }
-
+        include_context 'when bad request'
+        let(:random_thought) { bad_request }
         run_test!
       end
     end
@@ -82,54 +75,13 @@ RSpec.describe 'random_thoughts', type: :request do
 
       response(200, 'successful') do
         let(:id) { create(:random_thought).id }
-
         schema '$ref' => '#/components/schemas/random_thought'
-
-        after do |example|
-          example.metadata[:response][:content] = {
-            'application/json' => {
-              example: JSON.parse(response.body, symbolize_names: true)
-            }
-          }
-        end
-
         run_test!
       end
 
       response(404, 'not found') do
-        let(:id) { 0 }
-
-        schema '$ref' => '#/components/schemas/error'
-        example 'application/json', :not_found, {
-          status: 404,
-          error: 'not_found',
-          message: "Couldn't find RandomThought with 'id'=??"
-        }
-
+        include_context 'when not found'
         run_test!
-      end
-
-      # THIS TEST IS SKIPPED
-      # Unable to produce the test conditions for 500
-      response(500, 'internal server error') do
-        let(:id) { create(:random_thought).id }
-
-        schema '$ref' => '#/components/schemas/error'
-        example 'application/json', :internal_server_error, {
-          status: 500,
-          error: 'internal_server_error',
-          message: '...'
-        }
-
-        before do |example|
-          submit_request(example.metadata)
-        end
-
-        it 'returns a 500 response' do |example|
-          # SKIP !!!
-          skip
-          assert_response_matches_metadata(example.metadata)
-        end
       end
     end
 
@@ -142,32 +94,21 @@ RSpec.describe 'random_thoughts', type: :request do
 
       response(200, 'successful') do
         let(:id) { create(:random_thought).id }
-        let(:update) { build(:random_thought, thought: 'new thought', name: 'new name') }
-
+        let(:update) { build(:random_thought) }
         schema '$ref' => '#/components/schemas/random_thought'
+        run_test!
+      end
 
-        after do |example|
-          example.metadata[:response][:content] = {
-            'application/json' => {
-              example: JSON.parse(response.body, symbolize_names: true)
-            }
-          }
-        end
-
+      response(400, 'bad request') do
+        include_context 'when bad request'
+        let(:id) { create(:random_thought).id }
+        let(:update) { bad_request }
         run_test!
       end
 
       response(404, 'not found') do
-        let(:id) { 0 }
+        include_context 'when not found'
         let(:update) { build(:random_thought) }
-
-        schema '$ref' => '#/components/schemas/error'
-        example 'application/json', :not_found, {
-          status: 404,
-          error: 'not_found',
-          message: "Couldn't find RandomThought with 'id'=??"
-        }
-
         run_test!
       end
     end
@@ -178,31 +119,12 @@ RSpec.describe 'random_thoughts', type: :request do
 
       response(200, 'successful') do
         let(:id) { create(:random_thought).id }
-
         schema '$ref' => '#/components/schemas/random_thought'
-
-        after do |example|
-          example.metadata[:response][:content] = {
-            'application/json' => {
-              example: JSON.parse(response.body, symbolize_names: true)
-            }
-          }
-        end
-
         run_test!
       end
 
       response(404, 'not found') do
-        let(:id) { 0 }
-        let(:update) { build(:random_thought) }
-
-        schema '$ref' => '#/components/schemas/error'
-        example 'application/json', :not_found, {
-          status: 404,
-          error: 'not_found',
-          message: "Couldn't find RandomThought with 'id'=??"
-        }
-
+        include_context 'when not found'
         run_test!
       end
     end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -82,18 +82,6 @@ paths:
                     message: Couldn't find RandomThought with 'id'=??
               schema:
                 "$ref": "#/components/schemas/error"
-        '500':
-          description: internal server error
-          content:
-            application/json:
-              examples:
-                internal_server_error:
-                  value:
-                    status: 500
-                    error: internal_server_error
-                    message: "..."
-              schema:
-                "$ref": "#/components/schemas/error"
     patch:
       summary: update random_thought
       parameters: []
@@ -104,6 +92,23 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/random_thought"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              examples:
+                empty_request:
+                  value:
+                    status: 400
+                    error: bad_request
+                    message: param is missing or the value is empty:...
+                invalid_request:
+                  value:
+                    status: 400
+                    error: bad_request
+                    message: Error occurred while parsing request parameters
+              schema:
+                "$ref": "#/components/schemas/error"
         '404':
           description: not found
           content:


### PR DESCRIPTION
# What

This changeset removes unnecessary duplicated code and refactors the random_thoughts Swagger tests to use shared context.  It also adds the bad-request (400) specification to the update (patch) random_thought and removes the pending 500 internal server error test from `get /random_thoughts/{id}. 

Specifically...
- Removes unneeded after blocks (specification of examples comes from the referenced schema)
- Refactors 404 not found to shared_context
- Refactors 400 bad request to shared_context
- Adds 400 bad request test to update (patch)
- Removes pending 500 internal server error test from show

# Why

This reduces the maintenance costs, complexity, and risks associated with unused and duplicated code.

The pending 500 internal server error was removed because it is...
- unable to be run (hence pending) since the conditions can not be produced in the test
- an "unexpected" error
- fully tested in the ApplicationController controller test where its conditions can be produced

# Change Impact Analysis and Testing

Added 400 bad request update test is verified by...
- [x] Running new automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Removed 500 internal server error show test is verified by...
- [x] Running automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Refactored existing tests are verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Test validity (that they are doing and testing what is expected) is verified by..
- [x]  Adding `debugger` lines to each random_thoughts controller action and inspecting `params` and `RandomThought` database contents.
