### PR TITLE
Add Clarity and Certainty and Reduce Risk by Adding Bad Request Tests for Update RandomThought

### DIFF
--- a/spec/requests/create_random_thought_spec.rb
+++ b/spec/requests/create_random_thought_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../support/shared_examples/bad_request_response'
 require_relative '../support/shared_examples/random_thought_response'
 
 RSpec.describe 'post /random_thoughts/' do
@@ -31,17 +32,7 @@ RSpec.describe 'post /random_thoughts/' do
       end.not_to change(RandomThought, :count)
     end
 
-    it 'returns "status": 400' do
-      expect(json_body['status']).to be(400)
-    end
-
-    it 'returns "error": "bad_request"' do
-      expect(json_body['error']).to eql('bad_request')
-    end
-
-    it 'returns "message" indicating parameters are missing' do
-      expect(json_body['message']).to include('param is missing or the value is empty')
-    end
+    it_behaves_like 'bad_request response'
   end
 
   # TODO: Testing invalid json does not seem to be possible

--- a/spec/requests/update_random_thought_spec.rb
+++ b/spec/requests/update_random_thought_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../support/shared_examples/bad_request_response'
 require_relative '../support/shared_examples/not_found_response'
 
 RSpec.describe 'patch /random_thoughts/{id}' do
@@ -44,6 +45,16 @@ RSpec.describe 'patch /random_thoughts/{id}' do
     end
 
     it_behaves_like 'not_found response'
+  end
+
+  context 'when update parameters are missing in update request' do
+    let!(:random_thought) { create(:random_thought) }
+
+    before do
+      patch random_thought_path(random_thought), params: {}, as: :json
+    end
+
+    it_behaves_like 'bad_request response'
   end
 
   private

--- a/spec/support/shared_examples/bad_request_response.rb
+++ b/spec/support/shared_examples/bad_request_response.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'bad_request response' do
+  it 'returns "status": 400' do
+    expect(json_body['status']).to be(400)
+  end
+
+  it 'returns "error": "bad_request"' do
+    expect(json_body['error']).to eql('bad_request')
+  end
+
+  it 'returns "message" indicating parameters are missing' do
+    expect(json_body['message']).to include('param is missing or the value is empty')
+  end
+end

--- a/spec/support/shared_examples/not_found_response.rb
+++ b/spec/support/shared_examples/not_found_response.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples 'not_found response' do
     expect(json_body['error']).to eql('not_found')
   end
 
-  it 'returns "message": ...' do
+  it 'returns "message": indicating it could not find' do
     expect(json_body['message']).to include("Couldn't find ")
   end
 end


### PR DESCRIPTION
# What

This non-functional changeset adds tests for a bad request when updating a random thought (`patch /random_thoughts/{id}`). It also refactors the bad request expectations into a `shared_example`. 

# Why
Although this code path was tested in the create  random thought functional test, adding it to the update adds clarity (i.e. tests as verified documentation) to the expected behaviors when updating a random thought.  It also potentially reduces risk if the implementations for this condition ever diverges between the create and update actions.

# Change Impact Analysis and Testing

Added 400 bad request update test is verified by...
- [x] Running new automated tests (CI)
- [x] Manual inspection of tests' outputs

Refactored existing tests are verified by...
- [x] Running existing automated tests (CI)
- [x] Manual inspection of tests' outputs
