### PR TITLE
Ensure Value of RandomThoughts by Adding Non-Empty Validations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,3 +62,7 @@ group :development, :test do
   # Swagger specs
   gem 'rswag-specs'
 end
+
+group :test do
+  gem 'shoulda-matchers'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,8 @@ GEM
     rswag-ui (2.8.0)
       actionpack (>= 3.1, < 7.1)
       railties (>= 3.1, < 7.1)
+    shoulda-matchers (5.3.0)
+      activesupport (>= 5.2.0)
     thor (1.2.1)
     timeout (0.3.1)
     tzinfo (2.0.5)
@@ -218,6 +220,7 @@ DEPENDENCIES
   rswag-api
   rswag-specs
   rswag-ui
+  shoulda-matchers
   tzinfo-data
 
 RUBY VERSION

--- a/app/lib/error/error_handler.rb
+++ b/app/lib/error/error_handler.rb
@@ -18,6 +18,10 @@ module Error
           render_response(404, :not_found, e.to_s)
         end
 
+        rescue_from ActiveRecord::RecordInvalid do |e|
+          render_response(422, :unprocessable_entity, e.to_s)
+        end
+
         rescue_from ActionController::ParameterMissing,
                     ActionDispatch::Http::Parameters::ParseError do |e|
           render_response(400, :bad_request, e.to_s)

--- a/app/models/random_thought.rb
+++ b/app/models/random_thought.rb
@@ -3,4 +3,7 @@
 # Represents someone's random thought
 class RandomThought < ApplicationRecord
   default_scope -> { order(created_at: :desc) }
+
+  validates :thought, presence: true
+  validates :name, presence: true
 end

--- a/db/migrate/20230206223049_change_random_thoughts_not_nullable.rb
+++ b/db/migrate/20230206223049_change_random_thoughts_not_nullable.rb
@@ -1,0 +1,6 @@
+class ChangeRandomThoughtsNotNullable < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null(:random_thoughts, :thought, false)
+    change_column_null(:random_thoughts, :name, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_31_170025) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_06_223049) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "random_thoughts", force: :cascade do |t|
-    t.string "thought"
-    t.string "name"
+    t.string "thought", null: false
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["created_at"], name: "index_random_thoughts_on_created_at"

--- a/spec/models/random_thought_spec.rb
+++ b/spec/models/random_thought_spec.rb
@@ -3,9 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe RandomThought do
-  it 'returns most recent first' do
-    create_list(:random_thought, 20)
-    most_recent = create(:random_thought)
-    expect(described_class.first).to eql(most_recent)
+  describe 'default scope' do
+    it 'returns most recent first' do
+      create_list(:random_thought, 20)
+      most_recent = create(:random_thought)
+      expect(described_class.first).to eql(most_recent)
+    end
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:thought) }
+    it { is_expected.to validate_presence_of(:name) }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,7 +7,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
-# --- CUSTOM ---
+# --- CUSTOM REQUIRES ---
 require_relative 'support/factory_bot'
 
 require_relative 'support/api_helper'
@@ -66,4 +66,13 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+end
+
+# --- CUSTOM ADDITIONAL CONFIGURATION ---
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
 end

--- a/spec/requests/create_random_thought_spec.rb
+++ b/spec/requests/create_random_thought_spec.rb
@@ -3,8 +3,17 @@
 require 'rails_helper'
 require_relative '../support/shared_examples/bad_request_response'
 require_relative '../support/shared_examples/random_thought_response'
+require_relative '../support/shared_examples/unprocessable_entity_response'
 
 RSpec.describe 'post /random_thoughts/' do
+  shared_examples 'RandomThought not created' do
+    it 'does not create a new RandomThought', :skip_before do
+      expect do
+        post_empty_request
+      end.not_to change(RandomThought, :count)
+    end
+  end
+
   context 'when valid create request' do
     let(:random_thought) { build(:random_thought) }
 
@@ -26,16 +35,24 @@ RSpec.describe 'post /random_thoughts/' do
       post_empty_request unless example.metadata[:skip_before]
     end
 
-    it 'does not create a new RandomThought', :skip_before do
-      expect do
-        post_empty_request
-      end.not_to change(RandomThought, :count)
-    end
+    it_behaves_like 'RandomThought not created'
 
     it_behaves_like 'bad_request response'
   end
 
   # TODO: Testing invalid json does not seem to be possible
+
+  context 'when validations fail for create request' do
+    let(:not_valid) { build(:random_thought, thought: '', name: '') }
+
+    before do |example|
+      post_random_thought(not_valid) unless example.metadata[:skip_before]
+    end
+
+    it_behaves_like 'RandomThought not created'
+
+    it_behaves_like 'unprocessable_entity response'
+  end
 
   private
 

--- a/spec/requests/random_thoughts_spec.rb
+++ b/spec/requests/random_thoughts_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe 'random_thoughts' do
     }
   end
 
+  shared_context 'when unprocessable entity' do
+    let(:empty_values) { build(:random_thought, thought: '', name: '') }
+    schema '$ref' => '#/components/schemas/error'
+    example 'application/json', :unprocessable_entity, {
+      status: 422,
+      error: 'unprocessable_entity',
+      message: "Validation failed: Thought can't be blank, Name can't be blank"
+    }
+  end
+
   shared_context 'when bad request' do
     let(:bad_request) { {} }
     schema '$ref' => '#/components/schemas/error'
@@ -63,6 +73,12 @@ RSpec.describe 'random_thoughts' do
         let(:random_thought) { bad_request }
         run_test!
       end
+
+      response(422, 'unprocessable entity') do
+        include_context 'when unprocessable entity'
+        let(:random_thought) { empty_values }
+        run_test!
+      end
     end
   end
 
@@ -109,6 +125,13 @@ RSpec.describe 'random_thoughts' do
       response(404, 'not found') do
         include_context 'when not found'
         let(:update) { build(:random_thought) }
+        run_test!
+      end
+
+      response(422, 'unprocessable entity') do
+        include_context 'when unprocessable entity'
+        let(:id) { create(:random_thought).id }
+        let(:update) { empty_values }
         run_test!
       end
     end

--- a/spec/requests/update_random_thought_spec.rb
+++ b/spec/requests/update_random_thought_spec.rb
@@ -3,37 +3,68 @@
 require 'rails_helper'
 require_relative '../support/shared_examples/bad_request_response'
 require_relative '../support/shared_examples/not_found_response'
+require_relative '../support/shared_examples/unprocessable_entity_response'
 
 RSpec.describe 'patch /random_thoughts/{id}' do
+  shared_examples 'RandomThought not updated' do
+    it 'does not update RandomThought' do
+      last_update = RandomThought.find(random_thought.id).updated_at
+      expect(last_update).to eql(random_thought.created_at)
+    end
+  end
+
   context 'when {id} exists' do
     let!(:random_thought) { create(:random_thought) }
-    let(:new_thought) { 'I like turtles' }
-    let(:new_name) { 'Jonathan "Zombie Kid" Ware' }
 
-    it 'does not change the number of RandomThoughts' do
-      expect do
+    context 'when valid update request' do
+      let(:new_thought) { 'I like turtles' }
+      let(:new_name) { 'Jonathan "Zombie Kid" Ware' }
+
+      it 'does not change the number of RandomThoughts' do
+        expect do
+          patch_random_thought(random_thought, new_thought:, new_name:)
+        end.not_to change(RandomThought, :count)
+      end
+
+      it 'updates thought when supplied' do
+        patch_random_thought(random_thought, new_thought:)
+        expect(random_thought.reload.thought).to eql(new_thought)
+      end
+
+      it 'updates name when supplied' do
+        patch_random_thought(random_thought, new_name:)
+        expect(random_thought.reload.name).to eql(new_name)
+      end
+
+      it 'returns "id": id' do
         patch_random_thought(random_thought, new_thought:, new_name:)
-      end.not_to change(RandomThought, :count)
+        expect(json_body['id']).to eql(random_thought.id)
+      end
+
+      it 'returns updated random_thought JSON' do
+        patch_random_thought(random_thought, new_thought:, new_name:)
+        expect(json_body).to be_random_thought_json(random_thought.reload)
+      end
     end
 
-    it 'updates thought when supplied' do
-      patch_random_thought(random_thought, new_thought:)
-      expect(random_thought.reload.thought).to eql(new_thought)
+    context 'when update parameters are missing in update request' do
+      before do
+        patch random_thought_path(random_thought), params: {}, as: :json
+      end
+
+      it_behaves_like 'RandomThought not updated'
+
+      it_behaves_like 'bad_request response'
     end
 
-    it 'updates name when supplied' do
-      patch_random_thought(random_thought, new_name:)
-      expect(random_thought.reload.name).to eql(new_name)
-    end
+    context 'when validations fail for update request' do
+      before do
+        patch_random_thought(random_thought, new_thought: '', new_name: '')
+      end
 
-    it 'returns "id": id' do
-      patch_random_thought(random_thought, new_thought:, new_name:)
-      expect(json_body['id']).to eql(random_thought.id)
-    end
+      it_behaves_like 'RandomThought not updated'
 
-    it 'returns updated random_thought JSON' do
-      patch_random_thought(random_thought, new_thought:, new_name:)
-      expect(json_body).to be_random_thought_json(random_thought.reload)
+      it_behaves_like 'unprocessable_entity response'
     end
   end
 
@@ -45,16 +76,6 @@ RSpec.describe 'patch /random_thoughts/{id}' do
     end
 
     it_behaves_like 'not_found response'
-  end
-
-  context 'when update parameters are missing in update request' do
-    let!(:random_thought) { create(:random_thought) }
-
-    before do
-      patch random_thought_path(random_thought), params: {}, as: :json
-    end
-
-    it_behaves_like 'bad_request response'
   end
 
   private

--- a/spec/support/shared_examples/unprocessable_entity_response.rb
+++ b/spec/support/shared_examples/unprocessable_entity_response.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'unprocessable_entity response' do
+  it 'returns "status": 422' do
+    expect(json_body['status']).to be(422)
+  end
+
+  it 'returns "error": "not_found"' do
+    expect(json_body['error']).to eql('unprocessable_entity')
+  end
+
+  it 'returns "message": indicating validation failed' do
+    expect(json_body['message']).to include('Validation failed: ')
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -41,8 +41,8 @@ RSpec.configure do |config|
           new_random_thought: {
             type: 'object',
             properties: {
-              thought: { type: 'string' },
-              name: { type: 'string' }
+              thought: { type: 'string', minLength: 1 },
+              name: { type: 'string', minLength: 1 }
             },
             required: %w[thought name]
           },
@@ -58,8 +58,8 @@ RSpec.configure do |config|
           update_random_thought: {
             type: 'object',
             properties: {
-              thought: { type: 'string' },
-              name: { type: 'string' }
+              thought: { type: 'string', minLength: 1 },
+              name: { type: 'string', minLength: 1 }
             }
           },
           paginated_random_thoughts: {

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -48,6 +48,19 @@ paths:
                     message: Error occurred while parsing request parameters
               schema:
                 "$ref": "#/components/schemas/error"
+        '422':
+          description: unprocessable entity
+          content:
+            application/json:
+              examples:
+                unprocessable_entity:
+                  value:
+                    status: 422
+                    error: unprocessable_entity
+                    message: 'Validation failed: Thought can''t be blank, Name can''t
+                      be blank'
+              schema:
+                "$ref": "#/components/schemas/error"
       requestBody:
         content:
           application/json:
@@ -121,6 +134,19 @@ paths:
                     message: Couldn't find RandomThought with 'id'=??
               schema:
                 "$ref": "#/components/schemas/error"
+        '422':
+          description: unprocessable entity
+          content:
+            application/json:
+              examples:
+                unprocessable_entity:
+                  value:
+                    status: 422
+                    error: unprocessable_entity
+                    message: 'Validation failed: Thought can''t be blank, Name can''t
+                      be blank'
+              schema:
+                "$ref": "#/components/schemas/error"
       requestBody:
         content:
           application/json:
@@ -161,8 +187,10 @@ components:
       properties:
         thought:
           type: string
+          minLength: 1
         name:
           type: string
+          minLength: 1
       required:
       - thought
       - name
@@ -184,8 +212,10 @@ components:
       properties:
         thought:
           type: string
+          minLength: 1
         name:
           type: string
+          minLength: 1
     paginated_random_thoughts:
       type: object
       properties:


### PR DESCRIPTION
# What
This changeset adds non-empty validations to RandomThoughts (database model) ensuring that neither the `thought` nor `name` fields are empty.  Single character `thought`s (e.g. '?') and `name`s (e.g. 'M') are allowed.  Tests for these validations and the errors produced when the validations fail are also included as well as updates to the Swagger/OpenAPI specification.  

Also included in this changeset...
- Migration to prevent null values for RandomThought `thought` and `name` fields
- Tests to ensure that a RandomThought is not updated if the update request fails (e.g. validation failure)
- Addition of the [`shoulda-matchers`](https://github.com/thoughtbot/shoulda-matchers) gem and configuration for more concise model validation tests
- Addition of `ActiveRecord::RecordInvalid` exception handling (422 Unprocessable Entity)
- Refactoring as needed

# Why
A RandomThought with an empty `thought` and/or `name` is not considered valuable and allows for clutter and may impede or preclude future features or functionality.

# Change Impact Analysis and Testing
New non-empty validations verified by...
- [x] Running new automated tests (CI)
- [x] Manual inspection of tests' outputs

Refactored existing tests are verified by...
- [x] Running existing automated tests (CI)
- [x] Manual inspection of tests' outputs

Additional Swagger specifications of 422 Unprocessable Entity response are verified by...
- [x] Running new Swagger automated tests (CI)
- [x] Manual exploratory testing using Swagger UI
