### PR TITLE
Update Base Machine Image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,12 @@
 # bundle exec bin/rails server -p 3000 -b 0.0.0.0
 
 # --- Base Image ---
-ARG BASE_TAG=latest
-FROM brianjbayer/rails-7.0.4-ruby-3.2.0-dev:${BASE_TAG}
+# Base Image from...
+# https://github.com/brianjbayer/machine-images/tree/main/rails/debian/debian-11-ruby-3.2-rails-7.0.4/dev
+ARG BASE_TAG=33414f3011db8fc66f387dc348f5431520cf3e32
+ARG BASE_IMAGE_NAME=brianjbayer/debian-11-ruby-3.2-rails-7.0.4-dev
+ARG BASE_IMAGE=${BASE_IMAGE_NAME}:${BASE_TAG}
+FROM ${BASE_IMAGE}
 
 # Static config
 ARG APP_ROOT=/app

--- a/README.md
+++ b/README.md
@@ -47,31 +47,58 @@ This API contains the following endpoints...
 * **Delete** random thought {id}: `delete /random_thoughts/{id}`
 
 ## Development
-This project can be developed using the supplied basic, container-based
-development environment which includes `vim`, `git`, `curl`, and `psql`.
+This project can be developed using the supplied basic,
+container-based development environment which includes
+`vim`, `git`, `curl`, and `psql`.
 
-The containerized development environment contains this application
-along with an orchestrated PostgreSQL container.
+The containerized development environment contains this
+application along with an orchestrated PostgreSQL container.
 
-The development environment application container volume mounts your
-local source code to recognize and persist any changes.
+The development environment application container volume mounts
+your local source code to recognize and persist any changes.
 
-By default the development environment application container executes
-the `bash` shell providing a command line interface into the
-application container.
+By default the development environment application container
+executes the `bash` shell providing a command line interface
+into the application container.
 
-### To Build the Development Environment Image
+### To Develop Using the Container-Based Development Environment
+The easiest way to run the containerized development environment
+is with the docker-compose framework using the `dockercomposerun`
+script.
 
 > **PREREQUISITE:** Docker must be installed and running
 
-1. Run the following command to build the image...
+1. Run the following command to run the containerized development
+   environment...
    ```
-   docker build --no-cache -t brianjbayer/random_thoughts_api-dev .
+   ./script/dockercomposerun
    ```
 
-### To Run the Containerized Development Environment
-The easiest way to run the containerized development environment is with
-the docker-compose framework.
+   > This will pull and run the latest development environment
+   > image of this project along with the latest `postgres`
+   > image.
+
+2. To exit the containerized development environment, run the
+   following command ...
+   ```
+   exit
+   ```
+
+#### Building Your Own Development Environment Image
+You can also build and run your own development environment
+image.  This is helpful when you are updating gems or
+changing the `Dockerfile`.
+
+1. Run the following command to build your image...
+   ```
+   docker build --no-cache -t local-random_thoughts_api-dev .
+   ```
+
+2. Run the following command to run the containerized development
+   environment using your image...
+   ```
+   APP_IMAGE=local-random_thoughts_api-dev ./script/dockercomposerun
+   ```
 
 #### To Start the Containerized Development Environment
 


### PR DESCRIPTION
# What

This non-functional changeset updates the base *machine image* for this application in the `Dockerfile`. It also makes the base image tag and name specifiable through Docker build-time arguments (i.e. `--build-arg`).

Finally the README is updated in the Development section to document using the default development environment image or building and using your own image. 

# Why

This is to update to using the new source-code controlled base machine images and to provide more flexibility in building this application image locally for development.

# Change Impact Analysis and Testing

- [x] Vet that image can be built using default base machine image and that there are no regressions in functionality (CI)
- [x] Vet that container built with new default base machine image has no operational regressions (e.g. run tests, server, rails console, etc)
- [x] Vet that image can be built using specified base machine image (manual testing)
- [x] Vet README changes by manual inspection end executing documented commands
