### PR TITLE
Eliminate Possible Confusion by Removing Duplication of Running Development Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ script.
    exit
    ```
 
-#### Building Your Own Development Environment Image
+#### Building And Running Your Own Development Environment Image
 You can also build and run your own development environment
 image.  This is helpful when you are updating gems or
 changing the `Dockerfile`.
@@ -98,20 +98,6 @@ changing the `Dockerfile`.
    environment using your image...
    ```
    APP_IMAGE=local-random_thoughts_api-dev ./script/dockercomposerun
-   ```
-
-#### To Start the Containerized Development Environment
-
-1. Run the following command to run the containerized development
-   environment...
-   ```
-   ./script/dockercomposerun
-   ```
-
-2. To exit the containerized development environment, run the
-   following command ...
-   ```
-   exit
    ```
 
 ### Mappings to Host Machine


### PR DESCRIPTION
# What
This non-functional, documentation-only changeset removes duplication of running the containerized development environment in the project README.

# Why
When last updating the README to add instructions on building and using your own development environment image, the original instructions were left resulting in duplication.  This changeset remove that duplication to avoid any possible confusion and to make the instructions more clear and concise.

# Change Impact Analysis and Testing
- [x] Vet that there are no regressions by running all automated tests (CI)
- [ ] Manual inspection of README
