### PR TITLE
Prepare for Adding Authorization and Authentication by Adding a User Model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Represents a user of this application
+class User < ApplicationRecord
+  validates :email, presence: true, uniqueness: true,
+                    # NOTE: citext (db) does not support max length constraint
+                    length: {
+                      # Max email address length is actually 254
+                      # see https://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690
+                      maximum: 254
+                    },
+                    format: {
+                      with: URI::MailTo::EMAIL_REGEXP,
+                      message: 'must match URI::MailTo::EMAIL_REGEXP'
+                    }
+
+  validates :display_name, presence: true
+end

--- a/db/migrate/20230216195842_create_users.rb
+++ b/db/migrate/20230216195842_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    enable_extension(:citext)
+    create_table :users do |t|
+      t.citext :email, null: false, index: { unique: true }
+      t.string :display_name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_06_223049) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_16_195842) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "plpgsql"
 
   create_table "random_thoughts", force: :cascade do |t|
@@ -20,6 +21,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_06_223049) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["created_at"], name: "index_random_thoughts_on_created_at"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.citext "email", null: false
+    t.string "display_name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user do
+    email { Faker::Internet.email }
+    display_name { Faker::Name.name }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User do
+  describe 'validations' do
+    describe 'email' do
+      let(:valid_but_rejected_email) { '"Some spaces! And @ sign too!" @some.server.com' }
+      let(:invalid_emails) do
+        %w[user@example,com user_at_foo.org user.name@example.
+           foo@bar_baz.com foo@bar+baz.com foo@bar..com]
+      end
+
+      it { is_expected.to validate_presence_of(:email) }
+
+      it { is_expected.to validate_length_of(:email).is_at_most(254) }
+
+      # Note that since emails are stored as case-insensitive
+      # in the database, can not use the validate_uniqueness_of
+      # shoulda matcher as it validates case-sensitivity
+      # rubocop:disable RSpec/MultipleExpectations
+      it 'is expected to validate that :email is case-insenitive unique' do
+        downcase_email = Faker::Internet.email.downcase
+        user = create(:user, email: downcase_email)
+        new_user = build(:user, email: user.email.upcase)
+        # Although there are two expectations, this is a single
+        # logical assertion (and valid? must be called
+        # to get errors)
+        expect(new_user.valid?).to be(false)
+        expect(new_user.errors.full_messages).to include('Email has already been taken')
+      end
+      # rubocop:enable RSpec/MultipleExpectations
+
+      # Test email format validation with positive and negative cases
+      it { is_expected.to allow_value(Faker::Internet.email).for(:email) }
+      it { is_expected.not_to allow_values(invalid_emails, valid_but_rejected_email).for(:email) }
+    end
+
+    describe 'display_name' do
+      it { is_expected.to validate_presence_of(:display_name) }
+    end
+  end
+end


### PR DESCRIPTION
# What
This changeset adds a simple `User` model with an email address and display name.

# Why
This is in preparation for adding authentication and authorization security to the application.

# Change Impact Analysis and Testing
This change set should not change any existing functionality nor introduce any user-visible functionality.
New `model` unit tests are added for the new `User` model.

Verified no regressions in application functionality by...
- [x] Running automated tests (CI)

Verified new `User` model and its validations by...
 - [x] Running automated tests (CI)
