### PR TITLE
Correct the Random Thought Swagger Specifications for Create and Update 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ This API contains the following endpoints...
   with Request Body...
   ```json
   {
-    "thought": "string",
-    "name": "string"
+    "random_thought": {
+      "thought": "string",
+      "name": "string"
+    }
   }
   ```
 
@@ -39,8 +41,10 @@ This API contains the following endpoints...
   with Request Body...
   ```json
   {
-    "thought": "string",
-    "name": "string"
+    "random_thought": {
+      "thought": "string",
+      "name": "string"
+    }
   }
   ```
 

--- a/spec/factories/random_thoughts.rb
+++ b/spec/factories/random_thoughts.rb
@@ -4,5 +4,18 @@ FactoryBot.define do
   factory :random_thought do
     thought { Faker::Lorem.sentence }
     name { Faker::Name.name }
+
+    trait :empty_thought do
+      thought { '' }
+    end
+
+    trait :empty_name do
+      name { '' }
+    end
+
+    trait :empty do
+      empty_thought
+      empty_name
+    end
   end
 end

--- a/spec/requests/create_random_thought_spec.rb
+++ b/spec/requests/create_random_thought_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../support/random_thought_helper'
 require_relative '../support/shared_examples/bad_request_response'
 require_relative '../support/shared_examples/is_created_from_request'
 require_relative '../support/shared_examples/not_created_from_request'
@@ -8,6 +9,8 @@ require_relative '../support/shared_examples/random_thought_response'
 require_relative '../support/shared_examples/unprocessable_entity_response'
 
 RSpec.describe 'post /random_thoughts/' do
+  include RandomThoughtHelper
+
   context 'when valid create request' do
     subject(:request) { post_random_thought(random_thought) }
 
@@ -39,7 +42,7 @@ RSpec.describe 'post /random_thoughts/' do
   context 'when validations fail for create request' do
     subject(:request) { post_random_thought(not_valid) }
 
-    let(:not_valid) { build(:random_thought, thought: '', name: '') }
+    let(:not_valid) { build(:random_thought, :empty) }
 
     before do |example|
       request unless example.metadata[:skip_before]
@@ -53,11 +56,6 @@ RSpec.describe 'post /random_thoughts/' do
   private
 
   def post_random_thought(random_thought)
-    post random_thoughts_path, params: {
-      random_thought: {
-        thought: random_thought.thought,
-        name: random_thought.name
-      }
-    }
+    post random_thoughts_path, params: build_random_thought_body(random_thought)
   end
 end

--- a/spec/requests/random_thoughts_spec.rb
+++ b/spec/requests/random_thoughts_spec.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 require 'swagger_helper'
+require_relative '../support/random_thought_helper'
 require_relative '../support/shared_contexts/when_bad_request'
 require_relative '../support/shared_examples/unprocessable_entity_schema'
 
 RSpec.describe 'random_thoughts' do
+  include RandomThoughtHelper
+
   shared_context 'when not found' do
     let(:id) { 0 }
     schema '$ref' => '#/components/schemas/error'
@@ -39,11 +42,11 @@ RSpec.describe 'random_thoughts' do
       produces 'application/json'
       parameter name: :random_thought,
                 in: :body,
-                schema: { '$ref' => '#/components/schemas/new_random_thought' }
+                schema: { '$ref' => '#/components/schemas/create_random_thought' }
 
       response(201, 'created') do
-        let(:random_thought) { build(:random_thought) }
-        schema '$ref' => '#/components/schemas/random_thought'
+        let(:random_thought) { build_random_thought_body(build(:random_thought)) }
+        schema '$ref' => '#/components/schemas/random_thought_response'
         run_test!
       end
 
@@ -56,7 +59,7 @@ RSpec.describe 'random_thoughts' do
       response(422, 'unprocessable entity') do
         msg = "Validation failed: Thought can't be blank, Name can't be blank"
         it_behaves_like 'unprocessable entity schema', msg
-        let(:empty_values) { build(:random_thought, thought: '', name: '') }
+        let(:empty_values) { build_random_thought_body(build(:random_thought, :empty)) }
         let(:random_thought) { empty_values }
         run_test!
       end
@@ -72,7 +75,7 @@ RSpec.describe 'random_thoughts' do
 
       response(200, 'successful') do
         let(:id) { create(:random_thought).id }
-        schema '$ref' => '#/components/schemas/random_thought'
+        schema '$ref' => '#/components/schemas/random_thought_response'
         run_test!
       end
 
@@ -91,8 +94,8 @@ RSpec.describe 'random_thoughts' do
 
       response(200, 'successful') do
         let(:id) { create(:random_thought).id }
-        let(:update) { build(:random_thought) }
-        schema '$ref' => '#/components/schemas/random_thought'
+        let(:update) { build_random_thought_body(build(:random_thought)) }
+        schema '$ref' => '#/components/schemas/random_thought_response'
         run_test!
       end
 
@@ -105,7 +108,7 @@ RSpec.describe 'random_thoughts' do
 
       response(404, 'not found') do
         include_context 'when not found'
-        let(:update) { build(:random_thought) }
+        let(:update) { build_random_thought_body(build(:random_thought)) }
         run_test!
       end
 
@@ -113,7 +116,7 @@ RSpec.describe 'random_thoughts' do
         msg = "Validation failed: Thought can't be blank, Name can't be blank"
         it_behaves_like 'unprocessable entity schema', msg
         let(:id) { create(:random_thought).id }
-        let(:empty_values) { build(:random_thought, thought: '', name: '') }
+        let(:empty_values) { build_random_thought_body(build(:random_thought, :empty)) }
         let(:update) { empty_values }
         run_test!
       end
@@ -125,7 +128,7 @@ RSpec.describe 'random_thoughts' do
 
       response(200, 'successful') do
         let(:id) { create(:random_thought).id }
-        schema '$ref' => '#/components/schemas/random_thought'
+        schema '$ref' => '#/components/schemas/random_thought_response'
         run_test!
       end
 

--- a/spec/support/random_thought_helper.rb
+++ b/spec/support/random_thought_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module RandomThoughtHelper
+  def build_random_thought_body(random_thought)
+    {
+      random_thought: {
+        thought: random_thought.thought,
+        name: random_thought.name
+      }
+    }
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -46,7 +46,14 @@ RSpec.configure do |config|
             },
             required: %w[thought name]
           },
-          random_thought: {
+          create_random_thought: {
+            type: 'object',
+            properties: {
+              random_thought: { '$ref' => '#/components/schemas/new_random_thought' }
+            },
+            required: %w[random_thought]
+          },
+          random_thought_response: {
             type: 'object',
             properties: {
               id: { type: 'integer' },
@@ -55,19 +62,26 @@ RSpec.configure do |config|
             },
             required: %w[id thought name]
           },
-          update_random_thought: {
+          updated_random_thought: {
             type: 'object',
             properties: {
               thought: { type: 'string', minLength: 1 },
               name: { type: 'string', minLength: 1 }
             }
           },
+          update_random_thought: {
+            type: 'object',
+            properties: {
+              random_thought: { '$ref' => '#/components/schemas/updated_random_thought' }
+            },
+            required: %w[random_thought]
+          },
           paginated_random_thoughts: {
             type: 'object',
             properties: {
               data: {
                 type: :array,
-                items: { '$ref' => '#/components/schemas/random_thought' }
+                items: { '$ref' => '#/components/schemas/random_thought_response' }
               },
               meta: {
                 '$ref' => '#/components/schemas/pagination'

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -30,7 +30,7 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/random_thought"
+                "$ref": "#/components/schemas/random_thought_response"
         '400':
           description: bad request
           content:
@@ -65,7 +65,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/new_random_thought"
+              "$ref": "#/components/schemas/create_random_thought"
   "/random_thoughts/{id}":
     parameters:
     - name: id
@@ -82,7 +82,7 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/random_thought"
+                "$ref": "#/components/schemas/random_thought_response"
         '404':
           description: not found
           content:
@@ -104,7 +104,7 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/random_thought"
+                "$ref": "#/components/schemas/random_thought_response"
         '400':
           description: bad request
           content:
@@ -160,7 +160,7 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/random_thought"
+                "$ref": "#/components/schemas/random_thought_response"
         '404':
           description: not found
           content:
@@ -245,7 +245,14 @@ components:
       required:
       - thought
       - name
-    random_thought:
+    create_random_thought:
+      type: object
+      properties:
+        random_thought:
+          "$ref": "#/components/schemas/new_random_thought"
+      required:
+      - random_thought
+    random_thought_response:
       type: object
       properties:
         id:
@@ -258,7 +265,7 @@ components:
       - id
       - thought
       - name
-    update_random_thought:
+    updated_random_thought:
       type: object
       properties:
         thought:
@@ -267,13 +274,20 @@ components:
         name:
           type: string
           minLength: 1
+    update_random_thought:
+      type: object
+      properties:
+        random_thought:
+          "$ref": "#/components/schemas/updated_random_thought"
+      required:
+      - random_thought
     paginated_random_thoughts:
       type: object
       properties:
         data:
           type: array
           items:
-            "$ref": "#/components/schemas/random_thought"
+            "$ref": "#/components/schemas/random_thought_response"
         meta:
           "$ref": "#/components/schemas/pagination"
       required:


### PR DESCRIPTION
# What
This changeset corrects the Swagger (Open API) specifications and applicable code including tests to meet the actual expected body `params` for a RandomThought, specifically for create (`post /random_thoughts`) update (`patch /random_thoughts/{id}`.
This changeset also includes some refactoring including adding "empty" "traits" to the `random_thoughts` factory_bot Factory.

# Why
Although, the create and update RandomThought functionality worked, it was not correctly specified in Swagger nor in the Swagger Tests.  The `random_thoughts_controller` is defined as `params.required(:random_thought).permit(:thought, :name)` which would expect the body on create and update to be...
  ```json
  {
    "random_thought": {
      "thought": "string",
      "name": "string"
    }
  }
  ```
However, it was actually specified in Swagger as...
```json
{
  "thought": "string",
  "name": "string"
}
```

This was also the json format sent in the Swagger tests themselves.

# Change Impact Analysis and Testing


Changed functionality and specifications are verified by...
- [x] Running new automated tests with `params` inspection in Rails Console ( and CI)
- [x] Manual exploratory testing using Swagger UI

Refactored existing functionality is verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Updated documentation is verified by...
- [ ] Manual inspection of README
