### PR TITLE
For Best-Fit Practice, Add config/environments/default Mechanism 

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,23 +103,8 @@ script.
 
 #### PREREQUISITES
 In order to run the containerized development environment...
+
 1. Docker must be installed and running
-
-2. You must set the required environment variable `APP_JWT_SECRET`
-   > Note that to even generate a secret for setting `APP_JWT_SECRET`
-   > using the `rails secret` command, you must have already set
-   > `APP_JWT_SECRET` with an initial value.  You can use this
-   > hack...
-   > ```
-   > export APP_JWT_SECRET=chicken-to-lay-first-egg
-
-Provided that you have already set `APP_JWT_SECRET` to some initial
-value, to generate a suitable secret for setting `APP_JWT_SECRET`,
-you can use the `rails secret` command, for example...
-```
-APP_JWT_SECRET=$(bundle exec bin/rails secret)
-```
-
 
 #### Running the Containerized Development Environment
 1. Run the following command to run the containerized development
@@ -170,6 +155,25 @@ visibility and access.
 ---
 
 ## Operating
+
+### PREREQUISITES
+In order to run the rails commands for this application...
+
+1. You must set the required environment variable `APP_JWT_SECRET`
+   > Note that to even generate a secret for setting `APP_JWT_SECRET`
+   > using the `rails secret` command, you must have already set
+   > `APP_JWT_SECRET` with an initial value.  You can use this
+   > hack...
+   > ```
+   > export APP_JWT_SECRET=chicken-to-lay-first-egg
+   > ```
+
+Provided that you have already set `APP_JWT_SECRET` to some initial
+value, to generate a suitable secret for setting `APP_JWT_SECRET`,
+you can use the `rails secret` command, for example...
+```
+APP_JWT_SECRET=$(bundle exec bin/rails secret)
+```
 
 ### Database
 This project uses a Rails-supported PostgreSQL database with

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,8 +35,5 @@ module RandomThoughtsApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
-
-    #--- CUSTOM CONFIGURATION ---
-    config.jwt_secret = ENV.fetch('APP_JWT_SECRET')
   end
 end

--- a/config/environments/default.rb
+++ b/config/environments/default.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# This is default configuration intended to be common across
+# all environments.  Any environment-specific overides to
+# these defaults should be done in that specific environment's
+# configuration file.
+# NOTE: Settings specified here will take precedence over those
+# in config/application.rb.
+
+# TODO: This is currently a Work In Progress and will fully
+# addressed during productionization
+
+require 'active_support/core_ext/integer/time'
+
+Rails.application.configure do
+  #--- LOGGING ---
+  # Note this is modified from config/environments/production.rb
+  if ENV.include?('RAILS_LOG_TO_STDOUT')
+    logger           = ActiveSupport::Logger.new($stdout)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
+
+  #--- APPLICATION-SPECIFIC CONFIGURATION ---
+  config.jwt_secret = ENV.fetch('APP_JWT_SECRET')
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,8 @@
-require "active_support/core_ext/integer/time"
+# Based on defaults
+require Rails.root.join('config/environments/default')
+
+# TODO: Remove during default configuration refactor
+# require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,8 @@
-require "active_support/core_ext/integer/time"
+# Based on defaults
+require Rails.root.join('config/environments/default')
+
+# TODO: Remove during default configuration refactor
+# require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -75,11 +79,12 @@ Rails.application.configure do
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
+  # TODO: Remove during default configuration refactor
+  # if ENV["RAILS_LOG_TO_STDOUT"].present?
+  #   logger           = ActiveSupport::Logger.new(STDOUT)
+  #   logger.formatter = config.log_formatter
+  #   config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  # end
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,8 @@
-require "active_support/core_ext/integer/time"
+# Based on defaults
+require Rails.root.join('config/environments/default')
+
+# TODO: Remove during default configuration refactor
+# require "active_support/core_ext/integer/time"
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,4 +4,5 @@ services:
     image: brianjbayer/random_thoughts_api:${APP_TAG:-latest}
     container_name: ${APP_HOSTNAME:-app}
     environment:
+      - RAILS_LOG_TO_STDOUT
       - APP_JWT_SECRET


### PR DESCRIPTION
# What
This operational-only changeset adds a default configuration file (`config/environments/default.rb`) and mechanism for environment-specific configuration in `config/environments`.  This default is then loaded in to each of the standard rails environments' configuration files.

In addition...
- The fetch of the 'APP_JWT_SECRET' was moved from lower precedence `config/application.rb` to the higher precedence environments default
- The configuration logic of logging to `STDOUT` was moved from `config/environments/production.rb` into the new environments default
- Support for `RAILS_LOG_TO_STDOUT` environment variable was added to the app's docker-compose file
- Corrected README for formatting and operational prerequisites

# Why
This default mechanism is a first step in making the configuration across environments more common and applicable differences more apparent.  It also makes setting the logging to `STDOUT` easier in all environments (particularly `development`) by using an environment variable.

# Change Impact Analysis and Testing
This changeset is operational only.

No regressions in functionality vetted by...
- [x] Running functional automated tests (CI)

No regressions to `APP_JWT_SECRET` requirement and mechanism verified by...
- [x] Manual testing of running tests with `APP_JWT_SECRET` unset (failed to run)
- [x] Manual testing of running tests with `APP_JWT_SECRET` set (tests run and pass)

Ability to set logging to `STDOUT` verified by...
- [x] Manual testing of running tests with `RAILS_LOG_TO_STDOUT`unset and verifying logs sent to test log file only
- [x] Manual testing of running tests with `RAILS_LOG_TO_STDOUT`set and verifying logs sent to `STDOUT` only

Support for `RAILS_LOG_TO_STDOUT` in docker-compose verified by...
- [x] Manual testing of running framework with `RAILS_LOG_TO_STDOUT`unset and verifying logs sent to log file only
- [x] Manual testing of running framework with `RAILS_LOG_TO_STDOUT`set and verifying logs sent to `STDOUT` only

Correction to README verified by...
- [x] Manual inspection of rendered README on branch
