### PR TITLE
Increase Application Security by Adding Ability to Logout/Revoke Authorization for User

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ This API contains the following endpoints...
     }
     ```
 
+  * **Logout** user: `get /logout`
+    (e.g. http://localhost:3000/logout)
+    > **Requires** Authorization JWT from login
+    > in request header
+
 * User endpoints...
   * **Show** user {id}: `get /users/{id}`
     (e.g. http://localhost:3000/users/1)

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -3,18 +3,26 @@
 # Implements application authentication actions
 class AuthenticationController < ApplicationController
   include Authorization::JsonWebToken
+  include AuthorizeUserConcern
+
+  before_action :authorize_request, only: %i[logout]
 
   # Post /authentication/login
   def login
     @user = User.find_by(email: params[:authentication][:email])
     if @user&.authenticate(params[:authentication][:password])
-      # token = jwt_encode({ user: @user.id })
-      token = authentication_jwt({ user: @user.id })
+      token = authentication_jwt(app_payload(@user))
       logger.info "Login: Authenticated user [#{@user.email}]"
       render_logged_in(token)
     else
       render_error_response(:unauthorized, 'Invalid login')
     end
+  end
+
+  def logout
+    @current_user.revoke_auth
+    logger.info "Logout: Logged out user [#{@current_user.email}]"
+    render status: :ok, json: { message: 'User logged out successfully' }
   end
 
   private
@@ -23,6 +31,13 @@ class AuthenticationController < ApplicationController
     render status: :ok, json: {
       message: 'User logged in successfully',
       token:
+    }
+  end
+
+  def app_payload(user)
+    {
+      user: user.id,
+      auth: user.authorization_min
     }
   end
 end

--- a/app/controllers/concerns/authorize_user_concern.rb
+++ b/app/controllers/concerns/authorize_user_concern.rb
@@ -4,11 +4,13 @@
 module AuthorizeUserConcern
   extend ActiveSupport::Concern
   include Authorization::JsonWebToken
+  include Authorization::Errors
 
   included do
     def authorize_request
       decoded_jwt = decode_authentication_jwt(request_authorization_token)
       @current_user = User.find(decoded_jwt['user'])
+      validate_token(@current_user, decoded_jwt)
     end
   end
 
@@ -17,5 +19,9 @@ module AuthorizeUserConcern
   def request_authorization_token
     header = request.headers['Authorization']
     header&.split&.last
+  end
+
+  def validate_token(user, token)
+    raise Authorization::Errors::TokenRevokedError if user.auth_revoked?(token['auth'])
   end
 end

--- a/app/lib/authorization/errors.rb
+++ b/app/lib/authorization/errors.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Authorization
+  module Errors
+    class AuthorizationError < StandardError; end
+
+    # Custom exception for revoked authorization token (JWT)
+    class TokenRevokedError < AuthorizationError
+      def initialize
+        super('Unauthorized: User logged out or access revoked')
+      end
+    end
+  end
+end

--- a/app/lib/authorization/json_web_token.rb
+++ b/app/lib/authorization/json_web_token.rb
@@ -37,7 +37,7 @@ module Authorization
     private
 
     def required_claims
-      %w[aud exp iss user]
+      %w[aud exp iss user auth]
     end
 
     def valid_secret

--- a/app/lib/error/error_handler.rb
+++ b/app/lib/error/error_handler.rb
@@ -4,16 +4,18 @@ module Error
   # Handles expected and unexpected errors in a controlled manner
   # and message
   module ErrorHandler
+    include Authorization::Errors
+
     def self.included(including_class)
       # Handlers must be ordered in lowest to highest priority
       # (i.e. default must be first)
       including_class.class_eval do
-        # Default catch-all exception
+        #--- DEFAULT CATCH-ALL EXCEPTIONS ---
         rescue_from StandardError do |e|
           render_error_response(:internal_server_error, e.to_s)
         end
 
-        # Expected exceptions
+        #--- EXPECTED EXCEPTIONS ---
         rescue_from ActiveRecord::RecordNotFound do |e|
           render_error_response(:not_found, e.to_s)
         end
@@ -27,7 +29,12 @@ module Error
           render_error_response(:bad_request, e.to_s)
         end
 
-        #--- JWT Errors ---
+        #- Authorization Exceptions -
+        rescue_from AuthorizationError do |e|
+          render_error_response(:unauthorized, e.to_s)
+        end
+
+        #- JWT Exceptions -
         # JWT::DecodeError is the base decoding error
         rescue_from JWT::DecodeError do |e|
           render_error_response(:unauthorized, e.to_s)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,15 @@ class User < ApplicationRecord
   validates :display_name, presence: true
 
   has_secure_password
-  # TODO: When update is implemented...
-  # https://stackoverflow.com/questions/6486305/has-secure-password-how-to-require-minimum-length
-  validates :password, length: { minimum: PASSWORD_MIN_LENGTH }
+  validates :password, presence: true, length: { minimum: PASSWORD_MIN_LENGTH }, allow_nil: true
+
+  validates :authorization_min, presence: true, numericality: { only_integer: true }
+
+  def auth_revoked?(auth_value)
+    authorization_min > auth_value
+  end
+
+  def revoke_auth
+    update!(authorization_min: self.authorization_min += 1)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   post '/login', to: 'authentication#login', defaults: { format: 'json' }
+  get  '/logout', to: 'authentication#logout', defaults: { format: 'json' }
 
   get  '/users/:id', to: 'users#show', as: 'user', defaults: { format: 'json' }
   post '/users', to: 'users#create', defaults: { format: 'json' }

--- a/db/migrate/20230302151754_add_authorization_min_to_users.rb
+++ b/db/migrate/20230302151754_add_authorization_min_to_users.rb
@@ -1,0 +1,6 @@
+class AddAuthorizationMinToUsers < ActiveRecord::Migration[7.0]
+  def change
+    # This assume PostgreSQL where -9223372036854775808 is lowesrt bigint value
+    add_column :users, :authorization_min, :bigint, default: -9223372036854775808
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_20_195029) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_02_151754) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -29,6 +29,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_20_195029) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "password_digest"
+    t.bigint "authorization_min", default: -9223372036854775808
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -45,5 +45,39 @@ RSpec.describe User do
       it { is_expected.to have_secure_password }
       it { is_expected.to validate_length_of(:password).is_at_least(User::PASSWORD_MIN_LENGTH) }
     end
+
+    describe 'authorization_min' do
+      it { is_expected.to validate_presence_of(:authorization_min) }
+      it { is_expected.to validate_numericality_of(:authorization_min).only_integer }
+    end
+  end
+
+  describe 'methods' do
+    subject(:user) { create(:user) }
+
+    describe 'auth_revoked?' do
+      it 'returns true when authorization_min > value' do
+        user.authorization_min = Faker::Number.number
+        expect(user.auth_revoked?(user.authorization_min - 1)).to be(true)
+      end
+
+      it 'returns false when authorization_min = value' do
+        user.authorization_min = Faker::Number.number
+        expect(user.auth_revoked?(user.authorization_min)).to be(false)
+      end
+
+      it 'returns false when authorization_min < value' do
+        user.authorization_min = Faker::Number.number
+        expect(user.auth_revoked?(user.authorization_min + 1)).to be(false)
+      end
+    end
+
+    describe 'revoke_auth' do
+      it 'increments authorization_min by 1' do
+        initial_value = user.authorization_min
+        user.revoke_auth
+        expect(user.reload.authorization_min).to eql(initial_value + 1)
+      end
+    end
   end
 end

--- a/spec/requests/logout_spec.rb
+++ b/spec/requests/logout_spec.rb
@@ -3,58 +3,38 @@
 require 'rails_helper'
 
 require_relative '../support/helpers/jwt_helper'
-require_relative '../support/shared_examples/not_found_response'
-require_relative '../support/shared_examples/same_user_response'
 require_relative '../support/shared_examples/unauthorized_response'
 
-RSpec.describe 'get /user/{id}' do
+RSpec.describe 'get /logout' do
   include JwtHelper
 
   context 'when authorized' do
-    context "when {id} is current user's id" do
-      let(:user) { create(:user) }
-      let(:jwt) { valid_jwt(user) }
+    let(:user) { create(:user) }
+    let(:jwt) { valid_jwt(user) }
 
-      before do
-        get_user(user, jwt)
-      end
-
-      it_behaves_like 'same user response'
+    before do |example|
+      get_logout(jwt) unless example.metadata[:skip_before]
     end
 
-    context "when {id} is different user's id" do
-      let(:jwt) { valid_jwt(create(:user)) }
-      let(:user) { create(:user) }
-
-      before do
-        get_user(user, jwt)
-      end
-
-      it 'only returns "display_name"' do
-        expect(json_body.keys).to eql(['display_name'])
-      end
-
-      it 'returns "display_name": display_name of requested user' do
-        expect(json_body['display_name']).to eql(user.display_name)
-      end
+    # TODO: Should this be user.id instead of email?
+    it 'logs that the user has been logged out', :skip_before do
+      allow(Rails.logger).to receive(:info)
+      get_logout(jwt)
+      expect(Rails.logger).to have_received(:info).with("Logout: Logged out user [#{user.email}]")
     end
 
-    context 'when {id} does not exist' do
-      let(:user) { create(:user) }
-      let(:jwt) { valid_jwt(user) }
-      let(:not_user) { build(:user).id = 0 }
+    it 'revokes users authorization' do
+      expect(user.reload.auth_revoked?(auth_value(jwt))).to be(true)
+    end
 
-      before do
-        get_user(not_user, jwt)
-      end
-
-      it_behaves_like 'not_found response'
+    it 'returns "message" indicating user logged out successfully' do
+      expect(json_body['message']).to include('User logged out successfully')
     end
   end
 
-  # TODO: Duplicated (diff is get user_path(user)) - Refactor with logout_spec
+  # TODO: Duplicated (diff is get logout_path) - Refactor with get_user_spec
   context 'when no authorization' do
-    subject(:request) { get user_path(user), params: {} }
+    subject(:request) { get logout_path }
 
     let(:user) { create(:user) }
 
@@ -71,14 +51,14 @@ RSpec.describe 'get /user/{id}' do
       user = create(:user)
       jwt = valid_jwt(user)
       user.revoke_auth
-      get_user(user, jwt)
+      get_logout(jwt)
     end
 
     it_behaves_like 'unauthorized response', 'Unauthorized: User logged out or access revoked'
   end
 
   context 'when JWT has invalid encoding' do
-    subject(:request) { get_user(user, jwt) }
+    subject(:request) { get_logout(jwt) }
 
     let(:user) { create(:user) }
     let(:jwt) { invalid_algorithm_jwt(user) }
@@ -91,7 +71,7 @@ RSpec.describe 'get /user/{id}' do
   end
 
   context 'when JWT has invalid signature' do
-    subject(:request) { get_user(user, jwt) }
+    subject(:request) { get_logout(jwt) }
 
     let(:user) { create(:user) }
     let(:jwt) { invalid_signature_jwt(user) }
@@ -104,7 +84,7 @@ RSpec.describe 'get /user/{id}' do
   end
 
   context 'when JWT has invalid audience' do
-    subject(:request) { get_user(user, jwt) }
+    subject(:request) { get_logout(jwt) }
 
     let(:user) { create(:user) }
     let(:jwt) { invalid_audience_jwt(user) }
@@ -117,7 +97,7 @@ RSpec.describe 'get /user/{id}' do
   end
 
   context 'when JWT has invalid issuer' do
-    subject(:request) { get_user(user, jwt) }
+    subject(:request) { get_logout(jwt) }
 
     let(:user) { create(:user) }
     let(:jwt) { invalid_issuer_jwt(user) }
@@ -130,7 +110,7 @@ RSpec.describe 'get /user/{id}' do
   end
 
   context 'when JWT has expired' do
-    subject(:request) { get_user(user, jwt) }
+    subject(:request) { get_logout(jwt) }
 
     let(:user) { create(:user) }
     let(:jwt) { expired_jwt(user) }
@@ -143,7 +123,7 @@ RSpec.describe 'get /user/{id}' do
   end
 
   context 'when JWT is misssing "user" claim' do
-    subject(:request) { get_user(user, jwt) }
+    subject(:request) { get_logout(jwt) }
 
     let(:user) { create(:user) }
     let(:jwt) { missing_user_claim_jwt(user) }
@@ -156,7 +136,7 @@ RSpec.describe 'get /user/{id}' do
   end
 
   context 'when JWT is misssing "auth" claim' do
-    subject(:request) { get_user(user, jwt) }
+    subject(:request) { get_logout(jwt) }
 
     let(:user) { create(:user) }
     let(:jwt) { missing_auth_claim_jwt(user) }
@@ -170,7 +150,7 @@ RSpec.describe 'get /user/{id}' do
 
   private
 
-  def get_user(user, jwt)
-    get user_path(user), headers: authorization_header(jwt)
+  def get_logout(jwt)
+    get logout_path, headers: authorization_header(jwt)
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -68,7 +68,8 @@ RSpec.describe 'users' do
       security [bearer: []]
 
       response(200, 'successful') do
-        let(:jwt) { valid_jwt(create(:user).id) }
+        # NOTE: This is intended to test different users
+        let(:jwt) { valid_jwt(create(:user)) }
         let(:id) { create(:user).id }
 
         schema oneOf: [{ '$ref' => '#/components/schemas/same_user_response' },
@@ -77,8 +78,9 @@ RSpec.describe 'users' do
       end
 
       response(401, 'unauthorized') do
-        let(:id) { create(:user).id }
-        let(:jwt) { invalid_signature_jwt(id) }
+        let(:user) { create(:user) }
+        let(:id) { user.id }
+        let(:jwt) { invalid_signature_jwt(user) }
         schema '$ref' => '#/components/schemas/error'
         example 'application/json', :unauthorized, {
           status: 401,
@@ -89,7 +91,7 @@ RSpec.describe 'users' do
       end
 
       response(404, 'not found') do
-        let(:jwt) { valid_jwt(create(:user).id) }
+        let(:jwt) { valid_jwt(create(:user)) }
         let(:id) { 0 }
         it_behaves_like 'not found schema', UserMessage.not_found
         run_test!

--- a/spec/support/helpers/jwt_helper.rb
+++ b/spec/support/helpers/jwt_helper.rb
@@ -4,47 +4,58 @@
 module JwtHelper
   include Authorization::JsonWebToken
 
+  def auth_value(jwt)
+    decode_authentication_jwt(jwt)['auth']
+  end
+
   def authorization_header(token)
     { 'Authorization' => "Bearer #{token}" }
   end
 
-  def valid_jwt(id)
-    authentication_jwt(app_payload(id))
+  def valid_jwt(user)
+    authentication_jwt(app_payload(user))
   end
 
-  def invalid_algorithm_jwt(id)
-    jwt_encode(valid_authentication_payload(app_payload(id)), algorithm: 'none')
+  def invalid_algorithm_jwt(user)
+    jwt_encode(valid_authentication_payload(app_payload(user)), algorithm: 'none')
   end
 
-  def invalid_signature_jwt(id)
-    jwt_encode(valid_authentication_payload(app_payload(id)), secret: 'not-the-encoded-secret')
+  def invalid_signature_jwt(user)
+    jwt_encode(valid_authentication_payload(app_payload(user)), secret: 'not-the-encoded-secret')
   end
 
-  def invalid_audience_jwt(id)
-    jwt_encode(invalid_payload(id, :aud, 'INVALID'))
+  def invalid_audience_jwt(user)
+    jwt_encode(invalid_payload(user, :aud, 'INVALID'))
   end
 
-  def invalid_issuer_jwt(id)
-    jwt_encode(invalid_payload(id, :iss, 'INVALID'))
+  def invalid_issuer_jwt(user)
+    jwt_encode(invalid_payload(user, :iss, 'INVALID'))
   end
 
-  def expired_jwt(id)
-    jwt_encode(invalid_payload(id, :exp, 1.second.ago.to_i))
+  def expired_jwt(user)
+    jwt_encode(invalid_payload(user, :exp, 1.second.ago.to_i))
   end
 
-  def missing_user_claim_jwt
-    authentication_jwt({})
+  def missing_user_claim_jwt(user)
+    authentication_jwt(app_payload(user, id: false))
+  end
+
+  def missing_auth_claim_jwt(user)
+    authentication_jwt(app_payload(user, auth: false))
   end
 
   private
 
-  def invalid_payload(id, key, value)
-    bad_payload = valid_authentication_payload(app_payload(id))
+  def invalid_payload(user, key, value)
+    bad_payload = valid_authentication_payload(app_payload(user))
     bad_payload[key] = value
     bad_payload
   end
 
-  def app_payload(id)
-    { user: id }
+  def app_payload(user, id: true, auth: true)
+    payload = {}
+    payload[:user] = user.id if id
+    payload[:auth] = user.authorization_min if auth
+    payload
   end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -149,6 +149,13 @@ RSpec.configure do |config|
             },
             required: %w[message token]
           },
+          logout_response: {
+            type: 'object',
+            properties: {
+              message: { type: 'string' }
+            },
+            required: %w[message]
+          },
           pagination: {
             type: 'object',
             properties: {

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -16,7 +16,6 @@ paths:
               examples:
                 successful_login:
                   value:
-                    status: 200
                     message: User logged in successfully
                     token: xxxxxxxx.xxxxxxxxxx.xxxxxx
               schema:
@@ -38,6 +37,34 @@ paths:
           application/json:
             schema:
               "$ref": "#/components/schemas/login"
+  "/logout":
+    get:
+      summary: logout
+      security:
+      - bearer: []
+      responses:
+        '200':
+          description: logged out
+          content:
+            application/json:
+              examples:
+                successful_logout:
+                  value:
+                    message: User logged out successfully
+              schema:
+                "$ref": "#/components/schemas/logout_response"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              examples:
+                unauthorized:
+                  value:
+                    status: 401
+                    error: unauthorized
+                    message: Nil JSON web token
+              schema:
+                "$ref": "#/components/schemas/error"
   "/random_thoughts":
     get:
       summary: list random_thoughts
@@ -453,6 +480,13 @@ components:
       required:
       - message
       - token
+    logout_response:
+      type: object
+      properties:
+        message:
+          type: string
+      required:
+      - message
     pagination:
       type: object
       properties:


### PR DESCRIPTION
# What
This changeset adds revocation of the users access token/JSON Web Token(JWT) that was returned when the user logged in by adding the the `get /logout` route.  This revocation of a user's authorization could also be done at the Rails console (or database level) if there was a security breach.

The revocation/validation of a user's authorization by access token employs a rather simple and performant approach.  When authorizing the user through the access token, an `auth` claim value in the token is compared against the `authorization_min` value stored in that  user's record in the database.  If the value stored in the database is greater than that in the token, the token is considered revoked and the user is not authorized and must reauthenticate (i.e. login).

# Why
Adding this revocation mechanism provide greater security to the user and the application by allowing the user to logout when no longer accessing the application or to revoke any compromised access tokens for that user.

# Change Impact Analysis and Testing
New functionality and specifications are verified by...
- [x] Running new automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Refactored existing functionality is verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Updated documentation is verified by...
- [x] Manual inspection of README 
