### PR TITLE
Add Ability to Delete User (delete /users/{id})

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ This API contains the following endpoints...
     }
     ```
 
+  * **Delete** user {id}: `delete /users/{id}`
+    > **Requires** Authorization JWT from login
+    > in request header
+
 * Random Thoughts endpoints...
   * **Index** all random thoughts: `get /random_thoughts?page={num}`
     (e.g. http://localhost:3000/random_thoughts?page=2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
 class ApplicationController < ActionController::API
+  include ApiResponder
+  include JwtAuthorizer
   include Error::ErrorHandler
 end

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -3,7 +3,6 @@
 # Implements application authentication actions
 class AuthenticationController < ApplicationController
   include Authorization::JsonWebToken
-  include AuthorizeUserConcern
 
   before_action :authorize_request, only: %i[logout]
 

--- a/app/controllers/concerns/api_responder.rb
+++ b/app/controllers/concerns/api_responder.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Module for rendering Common Response in Controllers
-module RenderResponseConcern
+module ApiResponder
   extend ActiveSupport::Concern
   included do
     def render_show_response(status)

--- a/app/controllers/concerns/jwt_authorizer.rb
+++ b/app/controllers/concerns/jwt_authorizer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Module for Authorizing a user from JWT in request header
-module AuthorizeUserConcern
+module JwtAuthorizer
   extend ActiveSupport::Concern
   include Authorization::JsonWebToken
   include Authorization::Errors
@@ -11,6 +11,10 @@ module AuthorizeUserConcern
       decoded_jwt = decode_authentication_jwt(request_authorization_token)
       @current_user = User.find(decoded_jwt['user'])
       validate_token(@current_user, decoded_jwt)
+    end
+
+    def authorize_current_user
+      raise Authorization::Errors::UnauthorizedUserError unless current_user?(@user)
     end
   end
 
@@ -23,5 +27,9 @@ module AuthorizeUserConcern
 
   def validate_token(user, token)
     raise Authorization::Errors::TokenRevokedError if user.auth_revoked?(token['auth'])
+  end
+
+  def current_user?(user)
+    user == @current_user
   end
 end

--- a/app/controllers/random_thoughts_controller.rb
+++ b/app/controllers/random_thoughts_controller.rb
@@ -2,8 +2,6 @@
 
 # Implements CRUD operations for RandomThought
 class RandomThoughtsController < ApplicationController
-  include RenderResponseConcern
-
   before_action :find_random_thought, only: %i[show update destroy]
 
   def index

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,11 +2,9 @@
 
 # Implements CRUD operations for User
 class UsersController < ApplicationController
-  include AuthorizeUserConcern
-  include RenderResponseConcern
-
-  before_action :authorize_request, only: %i[show]
-  before_action :find_user, only: %i[show]
+  before_action :authorize_request, only: %i[show destroy]
+  before_action :find_user, only: %i[show destroy]
+  before_action :authorize_current_user, only: %i[destroy]
 
   def show
     # before_actions and show view
@@ -20,6 +18,11 @@ class UsersController < ApplicationController
       # NOTE: Bad Requests are handled by error handler
       render_validation_error_response(@user)
     end
+  end
+
+  def destroy
+    @user.destroy!
+    render_show_response(:ok)
   end
 
   private

--- a/app/lib/authorization/errors.rb
+++ b/app/lib/authorization/errors.rb
@@ -10,5 +10,13 @@ module Authorization
         super('Unauthorized: User logged out or access revoked')
       end
     end
+
+    # Custom exception when user is not authorized for action
+    # (i.e. id is not current user's id)
+    class UnauthorizedUserError < AuthorizationError
+      def initialize
+        super('Unauthorized: User does not authorization for this action')
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,10 +2,8 @@ Rails.application.routes.draw do
   post '/login', to: 'authentication#login', defaults: { format: 'json' }
   get  '/logout', to: 'authentication#logout', defaults: { format: 'json' }
 
-  get  '/users/:id', to: 'users#show', as: 'user', defaults: { format: 'json' }
-  post '/users', to: 'users#create', defaults: { format: 'json' }
-
   resources :random_thoughts, defaults: { format: 'json' }
+  resources :users, defaults: { format: 'json' }, only: %i[show create destroy]
 
   mount Rswag::Api::Engine => '/api-docs'
   mount Rswag::Ui::Engine => '/api-docs'

--- a/spec/requests/create_random_thought_spec.rb
+++ b/spec/requests/create_random_thought_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require_relative '../support/helpers/random_thought_helper'
 require_relative '../support/shared_examples/bad_request_response'
 require_relative '../support/shared_examples/is_created_from_request'
-require_relative '../support/shared_examples/not_created_from_request'
+require_relative '../support/shared_examples/is_not_created_from_request'
 require_relative '../support/shared_examples/random_thought_response'
 require_relative '../support/shared_examples/unprocessable_entity_response'
 
@@ -32,7 +32,7 @@ RSpec.describe 'post /random_thoughts/' do
       request unless example.metadata[:skip_before]
     end
 
-    it_behaves_like 'not created from request', RandomThought
+    it_behaves_like 'is not created from request', RandomThought
 
     it_behaves_like 'bad_request response'
   end
@@ -48,7 +48,7 @@ RSpec.describe 'post /random_thoughts/' do
       request unless example.metadata[:skip_before]
     end
 
-    it_behaves_like 'not created from request', RandomThought
+    it_behaves_like 'is not created from request', RandomThought
 
     it_behaves_like 'unprocessable_entity response'
   end

--- a/spec/requests/create_user_spec.rb
+++ b/spec/requests/create_user_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require_relative '../support/helpers/user_helper'
 require_relative '../support/shared_examples/bad_request_response'
 require_relative '../support/shared_examples/is_created_from_request'
-require_relative '../support/shared_examples/not_created_from_request'
+require_relative '../support/shared_examples/is_not_created_from_request'
 require_relative '../support/shared_examples/same_user_response'
 require_relative '../support/shared_examples/unprocessable_entity_response'
 
@@ -32,7 +32,7 @@ RSpec.describe 'post /users/' do
       request unless example.metadata[:skip_before]
     end
 
-    it_behaves_like 'not created from request', User
+    it_behaves_like 'is not created from request', User
 
     it_behaves_like 'bad_request response'
   end
@@ -51,7 +51,7 @@ RSpec.describe 'post /users/' do
       expect(json_body['message']).to include('Email has already been taken')
     end
 
-    it_behaves_like 'not created from request', User
+    it_behaves_like 'is not created from request', User
 
     it_behaves_like 'unprocessable_entity response'
   end
@@ -65,7 +65,7 @@ RSpec.describe 'post /users/' do
       request unless example.metadata[:skip_before]
     end
 
-    it_behaves_like 'not created from request', User
+    it_behaves_like 'is not created from request', User
 
     it_behaves_like 'unprocessable_entity response'
   end

--- a/spec/requests/delete_random_thought_spec.rb
+++ b/spec/requests/delete_random_thought_spec.rb
@@ -1,26 +1,24 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../support/shared_examples/is_deleted_from_request'
 require_relative '../support/shared_examples/not_found_response'
 require_relative '../support/shared_examples/random_thought_response'
 
 RSpec.describe 'delete /random_thoughts/{id}' do
   context 'when {id} exists' do
-    let!(:random_thought) { create(:random_thought) }
+    let(:random_thought) { create(:random_thought) }
+    # Ensure object to delete is created before expect block in 'is deleted...'
+    # rubocop:disable RSpec/LetSetup
+    let!(:object_to_delete) { random_thought }
+    # rubocop:enable RSpec/LetSetup
+    let(:delete_request) { delete_random_thought(random_thought) }
 
     before do |example|
-      delete_random_thought(random_thought) unless example.metadata[:skip_before]
+      delete_request unless example.metadata[:skip_before]
     end
 
-    it 'deletes a RandomThought', :skip_before do
-      expect do
-        delete_random_thought(random_thought)
-      end.to change(RandomThought, :count).by(-1)
-    end
-
-    it 'deletes the random thought' do
-      expect(RandomThought.find_by(id: random_thought.id)).to be_nil
-    end
+    it_behaves_like 'is deleted from request', RandomThought
 
     it 'returns "id": id' do
       expect(json_body['id']).to eql(random_thought.id)

--- a/spec/requests/delete_user_spec.rb
+++ b/spec/requests/delete_user_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+require_relative '../support/helpers/jwt_helper'
+require_relative '../support/shared_examples/is_deleted_from_request'
+require_relative '../support/shared_examples/is_not_deleted_from_request'
+require_relative '../support/shared_examples/jwt_authorization'
+require_relative '../support/shared_examples/not_found_response'
+require_relative '../support/shared_examples/same_user_response'
+
+RSpec.describe 'delete /users/{id}' do
+  include JwtHelper
+
+  let(:user) { create(:user) }
+
+  describe 'authorization' do
+    let(:request_without_jwt) { delete user_path(user) }
+    let(:request_with_jwt) { delete_user(user, jwt) }
+
+    it_behaves_like 'jwt_authorization'
+  end
+
+  context 'when valid authorization' do
+    let(:valid_auth_jwt) { valid_jwt(user) }
+
+    context "when {id} is current user's id" do
+      # Ensure object to delete is created before expect block in 'is deleted...'
+      # rubocop:disable RSpec/LetSetup
+      let!(:object_to_delete) { user }
+      # rubocop:enable RSpec/LetSetup
+      let(:delete_request) { delete_user(user, valid_auth_jwt) }
+
+      before do |example|
+        delete_request unless example.metadata[:skip_before]
+      end
+
+      it_behaves_like 'is deleted from request', User
+
+      it 'returns "id": id' do
+        expect(json_body['id']).to eql(user.id)
+      end
+
+      it_behaves_like 'same user response'
+    end
+
+    context "when {id} is different user's id" do
+      # Ensure objects are created before expect block in 'is not deleted...'
+      # rubocop:disable RSpec/LetSetup
+      let!(:requesting_user) { user }
+      # rubocop:enable RSpec/LetSetup
+      let!(:requested_user) { create(:user) }
+      let(:delete_request) { delete_user(requested_user, valid_auth_jwt) }
+
+      before do |example|
+        delete_request unless example.metadata[:skip_before]
+      end
+
+      it_behaves_like 'is not deleted from request', User
+
+      it_behaves_like 'unauthorized response', 'Unauthorized: User does not authorization for this action'
+    end
+
+    context 'when {id} does not exist' do
+      let(:does_not_exist) { build(:user).id = 0 }
+
+      before do
+        delete_user(does_not_exist, valid_auth_jwt)
+      end
+
+      it_behaves_like 'not_found response'
+    end
+  end
+
+  private
+
+  def delete_user(user, jwt)
+    delete user_path(user), headers: authorization_header(jwt)
+  end
+end

--- a/spec/requests/get_user_spec.rb
+++ b/spec/requests/get_user_spec.rb
@@ -11,10 +11,13 @@ RSpec.describe 'get /user/{id}' do
   include JwtHelper
 
   let(:user) { create(:user) }
-  let(:request_without_jwt) { get user_path(user), params: {} }
-  let(:request_with_jwt) { get_user(user, jwt) }
 
-  it_behaves_like 'jwt_authorization'
+  describe 'authorization' do
+    let(:request_without_jwt) { get user_path(user), params: {} }
+    let(:request_with_jwt) { get_user(user, jwt) }
+
+    it_behaves_like 'jwt_authorization'
+  end
 
   context 'when valid authorization' do
     let(:valid_auth_jwt) { valid_jwt(user) }

--- a/spec/requests/logout_spec.rb
+++ b/spec/requests/logout_spec.rb
@@ -9,10 +9,13 @@ RSpec.describe 'get /logout' do
   include JwtHelper
 
   let(:user) { create(:user) }
-  let(:request_without_jwt) { get logout_path }
-  let(:request_with_jwt) { get_logout(jwt) }
 
-  it_behaves_like 'jwt_authorization'
+  describe 'authorization' do
+    let(:request_without_jwt) { get logout_path }
+    let(:request_with_jwt) { get_logout(jwt) }
+
+    it_behaves_like 'jwt_authorization'
+  end
 
   context 'when authorized' do
     let(:valid_auth_jwt) { valid_jwt(user) }

--- a/spec/requests/swagger_authentication_spec.rb
+++ b/spec/requests/swagger_authentication_spec.rb
@@ -5,6 +5,7 @@ require 'swagger_helper'
 require_relative '../support/helpers/jwt_helper'
 require_relative '../support/helpers/login_helper'
 require_relative '../support/shared_examples/bad_request_schema'
+require_relative '../support/shared_examples/unauthorized_schema'
 
 RSpec.describe 'authentications' do
   include JwtHelper
@@ -31,12 +32,7 @@ RSpec.describe 'authentications' do
       response(401, 'unauthorized') do
         # FYI: Totally empty, missing credentials, bad credentials all end up here
         let(:login) { empty_json_body }
-        schema '$ref' => '#/components/schemas/error'
-        example 'application/json', :unauthorized, {
-          status: 401,
-          error: 'unauthorized',
-          message: 'Invalid login'
-        }
+        it_behaves_like 'unauthorized schema', 'Invalid login'
         run_test!
       end
     end
@@ -65,12 +61,7 @@ RSpec.describe 'authentications' do
         # rubocop:disable RSpec/VariableName
         let(:Authorization) { '' }
         # rubocop:enable RSpec/VariableName
-        schema '$ref' => '#/components/schemas/error'
-        example 'application/json', :unauthorized, {
-          status: 401,
-          error: 'unauthorized',
-          message: 'Nil JSON web token'
-        }
+        it_behaves_like 'unauthorized schema', 'Nil JSON web token'
         run_test!
       end
     end

--- a/spec/support/shared_examples/is_deleted_from_request.rb
+++ b/spec/support/shared_examples/is_deleted_from_request.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'is deleted from request' do |class_under_test|
+  it "deletes a #{class_under_test.name}", :skip_before do
+    expect do
+      delete_request
+    end.to change(class_under_test, :count).by(-1)
+  end
+
+  it "deletes the #{class_under_test.name.downcase}" do
+    expect(class_under_test.find_by(id: object_to_delete.id)).to be_nil
+  end
+end

--- a/spec/support/shared_examples/is_not_created_from_request.rb
+++ b/spec/support/shared_examples/is_not_created_from_request.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'not created from request' do |class_under_test|
+RSpec.shared_examples 'is not created from request' do |class_under_test|
   it "does not create a new #{class_under_test.name}", :skip_before do
     expect do
       request

--- a/spec/support/shared_examples/is_not_deleted_from_request.rb
+++ b/spec/support/shared_examples/is_not_deleted_from_request.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'is not deleted from request' do |class_under_test|
+  it "does not delete a #{class_under_test.name}", :skip_before do
+    expect do
+      delete_request
+    end.not_to change(class_under_test, :count)
+  end
+end

--- a/spec/support/shared_examples/unauthorized_schema.rb
+++ b/spec/support/shared_examples/unauthorized_schema.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'unauthorized schema' do |message|
+  schema '$ref' => '#/components/schemas/error'
+  example 'application/json', :unauthorized, {
+    status: 401,
+    error: 'unauthorized',
+    message:
+  }
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -332,6 +332,41 @@ paths:
                     message: Couldn't find User with 'id'=??
               schema:
                 "$ref": "#/components/schemas/error"
+    delete:
+      summary: delete user
+      security:
+      - bearer: []
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/same_user_response"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              examples:
+                unauthorized:
+                  value:
+                    status: 401
+                    error: unauthorized
+                    message: Expected a different algorithm
+              schema:
+                "$ref": "#/components/schemas/error"
+        '404':
+          description: not found
+          content:
+            application/json:
+              examples:
+                not_found:
+                  value:
+                    status: 404
+                    error: not_found
+                    message: Couldn't find User with 'id'=??
+              schema:
+                "$ref": "#/components/schemas/error"
 servers:
 - url: https://{defaultHost}
   variables:


### PR DESCRIPTION
# What
This changeset adds new functionality to delete an existing user through the new API endpoint`delete /users/{id}`.  It also contains refactoring and renaming as appropriate for code quality and best-fit practices and patterns.

Specifically...
  - Moves common controller includes to ApplicationController
  - Renames controller concerns
  - Changes users routing to resources
  - Implements users#destroy
  - Adds delete user Swagger specification
  - Adds delete user functional tests
  - Refactors as applicable
  - Updates README to include new delete user endpoint

# Why
This adds ability and Swagger specification to delete a created user and ensure this ability throughout changes with automated tests.

# Change Impact Analysis and Testing

New functionality is verified by...
- [x] Running new automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Refactored existing functionality is verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Updated documentation is verified by...
- [x] Manual inspection of README
