### PR TITLE
Add Ability to Update User (patch /users/{id})

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ This API contains the following endpoints...
     }
     ```
 
+  * **Update** user {id}: `patch /users/{id}`
+    with Request Body...
+    ```json
+    {
+      "user": {
+        "email": "string",
+        "display_name": "string",
+        "password": "stringst",
+        "password_confirmation": "stringst"
+      }
+    }
+    ```
+    > **Requires** Authorization JWT from login
+    > in request header
+
   * **Delete** user {id}: `delete /users/{id}`
     > **Requires** Authorization JWT from login
     > in request header
@@ -231,7 +246,6 @@ Run the following command to run the dependency security scan...
 ```
 ./script/run depsecscan
 ```
-
 
 ### Running the Application
 Run the following command to run the Rails server...

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,9 +2,9 @@
 
 # Implements CRUD operations for User
 class UsersController < ApplicationController
-  before_action :authorize_request, only: %i[show destroy]
-  before_action :find_user, only: %i[show destroy]
-  before_action :authorize_current_user, only: %i[destroy]
+  before_action :authorize_request, only: %i[show update destroy]
+  before_action :find_user, only: %i[show update destroy]
+  before_action :authorize_current_user, only: %i[update destroy]
 
   def show
     # before_actions and show view
@@ -14,6 +14,15 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       render status: :created
+    else
+      # NOTE: Bad Requests are handled by error handler
+      render_validation_error_response(@user)
+    end
+  end
+
+  def update
+    if @user.update(user_params)
+      render_show_response(:ok)
     else
       # NOTE: Bad Requests are handled by error handler
       render_validation_error_response(@user)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   get  '/logout', to: 'authentication#logout', defaults: { format: 'json' }
 
   resources :random_thoughts, defaults: { format: 'json' }
-  resources :users, defaults: { format: 'json' }, only: %i[show create destroy]
+  resources :users, defaults: { format: 'json' }, only: %i[show create update destroy]
 
   mount Rswag::Api::Engine => '/api-docs'
   mount Rswag::Ui::Engine => '/api-docs'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,11 +2,10 @@
 
 FactoryBot.define do
   factory :user do
-    email { Faker::Internet.email }
-    display_name { Faker::Name.name }
-    passwd = Faker::Internet.password
-    password { passwd }
-    password_confirmation { passwd }
+    email { Faker::Internet.unique.email }
+    display_name { Faker::Name.unique.name }
+    password { Faker::Internet.unique.password }
+    password_confirmation { password }
 
     trait :empty_email do
       email { '' }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,7 @@ require_relative 'support/factory_bot'
 require_relative 'support/helpers/api_helper'
 require_relative 'support/matchers/be_error_json'
 require_relative 'support/matchers/be_random_thought_json'
+require_relative 'support/matchers/be_same_user_json'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -70,6 +71,11 @@ RSpec.configure do |config|
 end
 
 # --- CUSTOM ADDITIONAL CONFIGURATION ---
+RSpec.configure do |config|
+  # Faker values are only guaranteed unique for each top level
+  # example group
+  config.before(:all) { Faker::UniqueGenerator.clear }
+end
 
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|

--- a/spec/requests/swagger_users_spec.rb
+++ b/spec/requests/swagger_users_spec.rb
@@ -12,6 +12,13 @@ class UserMessage
   def self.not_found
     "Couldn't find User with 'id'=??"
   end
+
+  def self.all_validations_failed
+    'Validation failed: ' \
+      "Email can't be blank, Email must match URI::MailTo::EMAIL_REGEXP, " \
+      "Display name can't be blank, " \
+      "Password can't be blank, Password is too short (minimum is 8 characters)"
+  end
 end
 
 RSpec.describe 'users' do
@@ -43,18 +50,13 @@ RSpec.describe 'users' do
       end
 
       response(422, 'unprocessable entity') do
-        msg = 'Validation failed: ' \
-              "Email can't be blank, Email must match URI::MailTo::EMAIL_REGEXP, " \
-              "Display name can't be blank, " \
-              "Password can't be blank, Password is too short (minimum is 8 characters)"
-        it_behaves_like 'unprocessable entity schema', msg
+        it_behaves_like 'unprocessable entity schema', UserMessage.all_validations_failed
         example 'application/json', :email_exists, {
           status: 422,
           error: 'unprocessable_entity',
           message: 'Validation failed: Email has already been taken'
         }
-        let(:empty_values) { build(:user, :empty) }
-        let(:user) { empty_values }
+        let(:user) { build(:user, :empty) }
         run_test!
       end
     end
@@ -63,6 +65,10 @@ RSpec.describe 'users' do
   path '/users/{id}' do
     parameter name: 'id', in: :path, type: :string, description: 'id'
 
+    let(:user) { create(:user) }
+    let(:jwt) { valid_jwt(user) }
+    let(:id) { user.id }
+
     get('show user') do
       consumes 'application/json'
       produces 'application/json'
@@ -70,7 +76,6 @@ RSpec.describe 'users' do
 
       response(200, 'successful') do
         # NOTE: This is intended to test different users
-        let(:jwt) { valid_jwt(create(:user)) }
         let(:id) { create(:user).id }
 
         schema oneOf: [{ '$ref' => '#/components/schemas/same_user_response' },
@@ -79,17 +84,55 @@ RSpec.describe 'users' do
       end
 
       response(401, 'unauthorized') do
-        let(:user) { create(:user) }
-        let(:id) { user.id }
         let(:jwt) { invalid_signature_jwt(user) }
         it_behaves_like 'unauthorized schema', 'Signature verification failed'
         run_test!
       end
 
       response(404, 'not found') do
-        let(:jwt) { valid_jwt(create(:user)) }
         let(:id) { 0 }
         it_behaves_like 'not found schema', UserMessage.not_found
+        run_test!
+      end
+    end
+
+    patch('update user') do
+      consumes 'application/json'
+      produces 'application/json'
+      security [bearer: []]
+      parameter name: :update,
+                in: :body,
+                schema: { '$ref' => '#/components/schemas/update_user' }
+
+      response(200, 'successful') do
+        let(:update) { build_user_body(build(:user)) }
+        schema '$ref' => '#/components/schemas/same_user_response'
+        run_test!
+      end
+
+      response(400, 'bad request') do
+        let(:update) { empty_json_body }
+        it_behaves_like 'bad request schema'
+        run_test!
+      end
+
+      response(401, 'unauthorized') do
+        let(:jwt) { expired_jwt(user) }
+        let(:update) { build_user_body(build(:user)) }
+        it_behaves_like 'unauthorized schema', 'Signature has expired'
+        run_test!
+      end
+
+      response(404, 'not found') do
+        let(:update) { build_user_body(build(:user)) }
+        let(:id) { 0 }
+        it_behaves_like 'not found schema', UserMessage.not_found
+        run_test!
+      end
+
+      response(422, 'unprocessable entity') do
+        let(:update) { build_user_body(build(:user, :empty)) }
+        it_behaves_like 'unprocessable entity schema', UserMessage.all_validations_failed
         run_test!
       end
     end
@@ -100,23 +143,19 @@ RSpec.describe 'users' do
       security [bearer: []]
 
       response(200, 'successful') do
-        let(:user) { create(:user) }
         let(:jwt) { valid_jwt(user) }
-        let(:id) { user.id }
         schema '$ref' => '#/components/schemas/same_user_response'
         run_test!
       end
 
       response(401, 'unauthorized') do
-        let(:user) { create(:user) }
-        let(:id) { user.id }
         let(:jwt) { invalid_algorithm_jwt(user) }
         it_behaves_like 'unauthorized schema', 'Expected a different algorithm'
         run_test!
       end
 
       response(404, 'not found') do
-        let(:jwt) { valid_jwt(create(:user)) }
+        let(:jwt) { valid_jwt(user) }
         let(:id) { 0 }
         it_behaves_like 'not found schema', UserMessage.not_found
         run_test!

--- a/spec/requests/update_random_thought_spec.rb
+++ b/spec/requests/update_random_thought_spec.rb
@@ -1,69 +1,72 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+
+require_relative '../support/helpers/random_thought_helper'
 require_relative '../support/shared_examples/bad_request_response'
+require_relative '../support/shared_examples/is_not_updated_from_request'
 require_relative '../support/shared_examples/not_found_response'
 require_relative '../support/shared_examples/unprocessable_entity_response'
 
 RSpec.describe 'patch /random_thoughts/{id}' do
-  shared_examples 'RandomThought not updated' do
-    it 'does not update RandomThought' do
-      last_update = RandomThought.find(random_thought.id).updated_at
-      expect(last_update).to eql(random_thought.created_at)
-    end
-  end
+  include RandomThoughtHelper
+
+  # Ensure the random_thought is created before updating it
+  let!(:random_thought) { create(:random_thought) }
+  let(:random_thought_update) { build(:random_thought) }
+  let(:update) { build_random_thought_body(random_thought_update) }
 
   context 'when {id} exists' do
-    let!(:random_thought) { create(:random_thought) }
-
     context 'when valid update request' do
-      let(:new_thought) { 'I like turtles' }
-      let(:new_name) { 'Jonathan "Zombie Kid" Ware' }
-
       it 'does not change the number of RandomThoughts' do
         expect do
-          patch_random_thought(random_thought, new_thought:, new_name:)
+          patch_random_thought(random_thought, update)
         end.not_to change(RandomThought, :count)
       end
 
       it 'updates thought when supplied' do
-        patch_random_thought(random_thought, new_thought:)
-        expect(random_thought.reload.thought).to eql(new_thought)
+        just_thought = random_thought_update_just_keys(update, 'thought')
+        patch_random_thought(random_thought, just_thought)
+        expect(random_thought.reload.thought).to eql(random_thought_update.thought)
       end
 
       it 'updates name when supplied' do
-        patch_random_thought(random_thought, new_name:)
-        expect(random_thought.reload.name).to eql(new_name)
+        just_name = random_thought_update_just_keys(update, 'name')
+        patch_random_thought(random_thought, just_name)
+        expect(random_thought.reload.name).to eql(random_thought_update.name)
       end
 
       it 'returns "id": id' do
-        patch_random_thought(random_thought, new_thought:, new_name:)
+        patch_random_thought(random_thought, update)
         expect(json_body['id']).to eql(random_thought.id)
       end
 
       it 'returns updated random_thought JSON' do
-        patch_random_thought(random_thought, new_thought:, new_name:)
-        expect(json_body).to be_random_thought_json(random_thought.reload)
+        patch_random_thought(random_thought, update)
+        expect(json_body).to be_random_thought_json(random_thought_update)
       end
     end
 
     context 'when update parameters are missing in update request' do
+      let(:requesting) { random_thought }
+
       before do
-        patch random_thought_path(random_thought), params: empty_json_body, as: :json
+        patch random_thought_path(requesting), params: empty_json_body
       end
 
-      it_behaves_like 'RandomThought not updated'
-
+      it_behaves_like 'is not updated from request', RandomThought
       it_behaves_like 'bad_request response'
     end
 
     context 'when validations fail for update request' do
+      let(:requesting) { random_thought }
+
       before do
-        patch_random_thought(random_thought, new_thought: '', new_name: '')
+        empty_random_thought = build_random_thought_body(build(:random_thought, :empty))
+        patch_random_thought(requesting, empty_random_thought)
       end
 
-      it_behaves_like 'RandomThought not updated'
-
+      it_behaves_like 'is not updated from request', RandomThought
       it_behaves_like 'unprocessable_entity response'
     end
   end
@@ -72,7 +75,7 @@ RSpec.describe 'patch /random_thoughts/{id}' do
     let(:does_not_exist) { build(:random_thought).id = 0 }
 
     before do
-      patch_random_thought(does_not_exist, new_thought: '...', new_name: '...')
+      patch_random_thought(does_not_exist, update)
     end
 
     it_behaves_like 'not_found response'
@@ -80,10 +83,11 @@ RSpec.describe 'patch /random_thoughts/{id}' do
 
   private
 
-  def patch_random_thought(random_thought, new_thought: false, new_name: false)
-    update = {}
-    update['thought'] = new_thought if new_thought
-    update['name'] = new_name if new_name
-    patch random_thought_path(random_thought), params: update, as: :json
+  def patch_random_thought(random_thought, update)
+    patch random_thought_path(random_thought), params: update
+  end
+
+  def random_thought_update_just_keys(update, *keys)
+    json_body_just_keys(:random_thought, update, *keys)
   end
 end

--- a/spec/requests/update_user_spec.rb
+++ b/spec/requests/update_user_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+require_relative '../support/helpers/jwt_helper'
+require_relative '../support/helpers/user_helper'
+require_relative '../support/shared_examples/bad_request_response'
+require_relative '../support/shared_examples/is_not_updated_from_request'
+require_relative '../support/shared_examples/jwt_authorization'
+require_relative '../support/shared_examples/not_found_response'
+require_relative '../support/shared_examples/same_user_response'
+require_relative '../support/shared_examples/unprocessable_entity_response'
+
+# rubocop:disable RSpec/MultipleMemoizedHelpers
+RSpec.describe 'update /users/{id}' do
+  include JwtHelper
+  include UserHelper
+
+  # Ensure the user is created before updating it
+  let!(:user) { create(:user) }
+  let(:user_update) { build(:user) }
+  let(:update) { build_user_body(user_update) }
+  let(:valid_auth_jwt) { valid_jwt(user) }
+
+  describe 'authorization' do
+    let(:request_without_jwt) { patch user_path(user), params: update, as: :json }
+    let(:request_with_jwt) { patch_user(user, jwt, update) }
+
+    it_behaves_like 'jwt_authorization'
+  end
+
+  context 'when valid update request' do
+    context "when {id} is current user's id" do
+      it 'does not change the number of Users' do
+        expect do
+          patch_user(user, valid_auth_jwt, update)
+        end.not_to change(User, :count)
+      end
+
+      it 'updates email when supplied' do
+        just_email = user_update_just_keys(update, 'email')
+        patch_user(user, valid_auth_jwt, just_email)
+        expect(user.reload.email).to eql(user_update.email)
+      end
+
+      it 'updates display_name when supplied' do
+        just_display_name = user_update_just_keys(update, 'display_name')
+        patch_user(user, valid_auth_jwt, just_display_name)
+        expect(user.reload.display_name).to eql(user_update.display_name)
+      end
+
+      it 'updates password when supplied' do
+        just_password = user_update_just_keys(update, 'password', 'password_confirmation')
+        patch_user(user, valid_auth_jwt, just_password)
+        expect(user.reload.authenticate(user_update.password)).to eql(user)
+      end
+
+      it 'returns "id": id' do
+        patch_user(user, valid_auth_jwt, update)
+        expect(json_body['id']).to eql(user.id)
+      end
+
+      it 'returns updated same user JSON' do
+        patch_user(user, valid_auth_jwt, update)
+        expect(json_body).to be_same_user_json(user_update)
+      end
+    end
+
+    context "when {id} is different user's id" do
+      let(:requesting) { user }
+      let!(:requested) { create(:user) }
+
+      before do
+        patch_user(requested, valid_auth_jwt, update)
+      end
+
+      it_behaves_like 'is not updated from request', User
+      it_behaves_like 'unauthorized response', 'Unauthorized: User does not authorization for this action'
+    end
+  end
+
+  context 'when update parameters are missing in update request' do
+    let(:requesting) { user }
+
+    before do
+      patch user_path(requesting), params: empty_json_body, headers: authorization_header(valid_auth_jwt)
+    end
+
+    it_behaves_like 'is not updated from request', User
+    it_behaves_like 'bad_request response'
+  end
+
+  context 'when validations fail for update request' do
+    let(:requesting) { user }
+
+    before do
+      patch_user(requesting, valid_auth_jwt, build_user_body(build(:user, :empty)))
+    end
+
+    it_behaves_like 'is not updated from request', User
+    it_behaves_like 'unprocessable_entity response'
+  end
+
+  context 'when {id} does not exist' do
+    let(:does_not_exist) { build(:user).id = 0 }
+
+    before do
+      patch_user(does_not_exist, valid_auth_jwt, update)
+    end
+
+    it_behaves_like 'not_found response'
+  end
+
+  private
+
+  def patch_user(user, jwt, update)
+    patch user_path(user), params: update, headers: authorization_header(jwt)
+  end
+
+  def user_update_just_keys(update, *keys)
+    json_body_just_keys(:user, update, *keys)
+  end
+end
+# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/support/helpers/api_helper.rb
+++ b/spec/support/helpers/api_helper.rb
@@ -8,6 +8,12 @@ module ApiHelper
   def empty_json_body
     {}
   end
+
+  def json_body_just_keys(top_key, update, *keys)
+    update_just_key = {}
+    update_just_key[top_key] = update[top_key].slice(*keys)
+    update_just_key
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/helpers/random_thought_helper.rb
+++ b/spec/support/helpers/random_thought_helper.rb
@@ -2,11 +2,7 @@
 
 module RandomThoughtHelper
   def build_random_thought_body(random_thought)
-    {
-      random_thought: {
-        thought: random_thought.thought,
-        name: random_thought.name
-      }
-    }
+    body = random_thought.attributes.slice('thought', 'name')
+    { random_thought: body }
   end
 end

--- a/spec/support/helpers/user_helper.rb
+++ b/spec/support/helpers/user_helper.rb
@@ -2,14 +2,10 @@
 
 module UserHelper
   def build_user_body(user)
-    # We build this explicitly (vs. as_json) to populate password* attributes
-    {
-      user: {
-        email: user.email,
-        display_name: user.display_name,
-        password: user.password,
-        password_confirmation: user.password_confirmation
-      }
-    }
+    user_body = user.attributes.slice('email', 'display_name')
+    # NOTE: password attributes must be handled explicitly
+    user_body['password'] = user.password
+    user_body['password_confirmation'] = user.password_confirmation
+    { user: user_body }
   end
 end

--- a/spec/support/matchers/be_same_user_json.rb
+++ b/spec/support/matchers/be_same_user_json.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Custom RSpec Matcher to match critical
+# attribute values to be a user
+# JSON response when the current user
+# is the requested user
+module BeSameUserJson
+  class BeSameUserJson
+    def initialize(expected_user)
+      @expected_user = expected_user
+    end
+
+    def matches?(actual)
+      @actual = actual
+
+      @actual['email'] == @expected_user.email &&
+        @actual['display_name'] == @expected_user.display_name
+    end
+
+    def failure_message
+      "expected that actual: #{pretty(@actual)} would match " \
+        "expected: #{pretty(matched_expected)}"
+    end
+
+    def failure_message_when_negated
+      "expected that actual: #{pretty(@actual)} would not match " \
+        "expected: #{pretty(matched_expected)}"
+    end
+
+    private
+
+    def pretty(json)
+      JSON.pretty_generate(json)
+    end
+
+    def matched_expected
+      @expected_user.attributes.slice('id', 'email', 'display_name')
+    end
+  end
+
+  def be_same_user_json(expected_user)
+    BeSameUserJson.new(expected_user)
+  end
+end
+
+# Include the custom matcher in RSpec
+RSpec.configure do |config|
+  config.include BeSameUserJson
+end

--- a/spec/support/shared_examples/is_not_updated_from_request.rb
+++ b/spec/support/shared_examples/is_not_updated_from_request.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'is not updated from request' do |class_under_test|
+  it "does not update #{class_under_test.name}" do
+    last_update = class_under_test.find(requesting.id).updated_at
+    expect(last_update).to eql(requesting.created_at)
+  end
+end

--- a/spec/support/shared_examples/same_user_response.rb
+++ b/spec/support/shared_examples/same_user_response.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'same user response' do
-  it 'returns "email": email' do
-    expect(json_body['email']).to eql(user.email)
-  end
-
-  it 'returns "display_name": display_name' do
-    expect(json_body['display_name']).to eql(user.display_name)
+  it 'returns same user JSON with correct values' do
+    expect(json_body).to be_same_user_json(user)
   end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -127,6 +127,22 @@ RSpec.configure do |config|
             },
             required: %w[display_name]
           },
+          updated_user: {
+            type: 'object',
+            properties: {
+              email: { type: 'string', minLength: 1, maxLength: 254 },
+              display_name: { type: 'string', minLength: 1 },
+              password: { type: 'string', minLength: User::PASSWORD_MIN_LENGTH },
+              password_confirmation: { type: 'string', minLength: User::PASSWORD_MIN_LENGTH }
+            }
+          },
+          update_user: {
+            type: 'object',
+            properties: {
+              user: { '$ref' => '#/components/schemas/updated_user' }
+            },
+            required: %w[user]
+          },
           login_credentials: {
             type: 'object',
             properties: {

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -332,6 +332,79 @@ paths:
                     message: Couldn't find User with 'id'=??
               schema:
                 "$ref": "#/components/schemas/error"
+    patch:
+      summary: update user
+      security:
+      - bearer: []
+      parameters: []
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/same_user_response"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              examples:
+                empty_request:
+                  value:
+                    status: 400
+                    error: bad_request
+                    message: param is missing or the value is empty:...
+                invalid_request:
+                  value:
+                    status: 400
+                    error: bad_request
+                    message: Error occurred while parsing request parameters
+              schema:
+                "$ref": "#/components/schemas/error"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              examples:
+                unauthorized:
+                  value:
+                    status: 401
+                    error: unauthorized
+                    message: Signature has expired
+              schema:
+                "$ref": "#/components/schemas/error"
+        '404':
+          description: not found
+          content:
+            application/json:
+              examples:
+                not_found:
+                  value:
+                    status: 404
+                    error: not_found
+                    message: Couldn't find User with 'id'=??
+              schema:
+                "$ref": "#/components/schemas/error"
+        '422':
+          description: unprocessable entity
+          content:
+            application/json:
+              examples:
+                unprocessable_entity:
+                  value:
+                    status: 422
+                    error: unprocessable_entity
+                    message: 'Validation failed: Email can''t be blank, Email must
+                      match URI::MailTo::EMAIL_REGEXP, Display name can''t be blank,
+                      Password can''t be blank, Password is too short (minimum is
+                      8 characters)'
+              schema:
+                "$ref": "#/components/schemas/error"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/update_user"
     delete:
       summary: delete user
       security:
@@ -490,6 +563,29 @@ components:
           minLength: 1
       required:
       - display_name
+    updated_user:
+      type: object
+      properties:
+        email:
+          type: string
+          minLength: 1
+          maxLength: 254
+        display_name:
+          type: string
+          minLength: 1
+        password:
+          type: string
+          minLength: 8
+        password_confirmation:
+          type: string
+          minLength: 8
+    update_user:
+      type: object
+      properties:
+        user:
+          "$ref": "#/components/schemas/updated_user"
+      required:
+      - user
     login_credentials:
       type: object
       properties:


### PR DESCRIPTION
# What

This changeset adds new functionality to update a User through the new API endpoint`patch /users/{id}`.

Specifically...
* Adds `users_controller#update`
* Adds Swagger specifications for `patch /users/{id}`
* Adds functional tests for `patch /users/{id}`
* Adds uniqueness of `Faker`-based `Users` Factory data (Uniqueness is guaranteed at the top-level example groups)
* Refactoring of code under development and test
* Update README with new endpoint

# Why

This adds ability and Swagger specification to update a created User and ensures this ability throughout changes with automated tests.

# Change Impact Analysis and Testing

New functionality is verified by...
- [x] Running new automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Refactored existing functionality is verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Updated documentation is verified by...
- [x] Manual inspection of README
