### PR TITLE
Enhance Security by Revoking Authorization for Deleted Users

### DIFF
--- a/app/controllers/concerns/jwt_authorizer.rb
+++ b/app/controllers/concerns/jwt_authorizer.rb
@@ -9,7 +9,11 @@ module JwtAuthorizer
   included do
     def authorize_request
       decoded_jwt = decode_authentication_jwt(request_authorization_token)
-      @current_user = User.find(decoded_jwt['user'])
+      begin
+        @current_user = User.find(decoded_jwt['user'])
+      rescue ActiveRecord::RecordNotFound
+        raise Authorization::Errors::DeletedUserError
+      end
       validate_token(@current_user, decoded_jwt)
     end
 

--- a/app/lib/authorization/errors.rb
+++ b/app/lib/authorization/errors.rb
@@ -18,5 +18,12 @@ module Authorization
         super('Unauthorized: User does not authorization for this action')
       end
     end
+
+    # Custom exception when user record has been deleted
+    class DeletedUserError < AuthorizationError
+      def initialize
+        super('Unauthorized: User has been deleted')
+      end
+    end
   end
 end

--- a/spec/support/shared_examples/jwt_authorization.rb
+++ b/spec/support/shared_examples/jwt_authorization.rb
@@ -24,6 +24,19 @@ RSpec.shared_examples 'jwt_authorization' do
     it_behaves_like 'unauthorized response', 'Unauthorized: User logged out or access revoked'
   end
 
+  context 'when JWT user has been deleted' do
+    let(:jwt) { valid_jwt(user) }
+
+    before do
+      # Ensure jwt created before deleting user
+      jwt
+      user.destroy!
+      request_with_jwt
+    end
+
+    it_behaves_like 'unauthorized response', 'Unauthorized: User has been deleted'
+  end
+
   context 'when JWT has wrong encoding' do
     let(:jwt) { invalid_algorithm_jwt(user) }
 


### PR DESCRIPTION
# What
This changeset resolves the issue of a deleted user still being authorized with the Access Token(s) (i.e. JWT) and includes a new automated test for this situation.

# Why
Although the access token for the deleted user would expire, this changeset immediately prevents authorization with this token. 

# Change Impact Analysis and Testing

New functionality is verified by...
- [x] Running new automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

No regressions to existing functionality is verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

