### PR TITLE
Add Ability to Get All Users (get /users/) with Pagination 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ This API contains the following endpoints...
     > in request header
 
 * User endpoints...
+  * **Index** all users: `get /users?page={num}`
+    (e.g. http://localhost:3000/users?page=2)
+    > **Requires** Authorization JWT from login
+    > in request header
+
   * **Show** user {id}: `get /users/{id}`
     (e.g. http://localhost:3000/users/1)
     > **Requires** Authorization JWT from login

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,9 +2,13 @@
 
 # Implements CRUD operations for User
 class UsersController < ApplicationController
-  before_action :authorize_request, only: %i[show update destroy]
+  before_action :authorize_request, only: %i[index show update destroy]
   before_action :find_user, only: %i[show update destroy]
   before_action :authorize_current_user, only: %i[update destroy]
+
+  def index
+    @users = User.page(params[:page])
+  end
 
   def show
     # before_actions and show view

--- a/app/views/meta/_meta.json.jbuilder
+++ b/app/views/meta/_meta.json.jbuilder
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+json.meta do
+  json.current_page items.current_page
+  json.next_page items.next_page
+  json.prev_page items.prev_page
+  json.total_pages items.total_pages
+  json.total_count item_class.count
+end

--- a/app/views/random_thoughts/index.json.jbuilder
+++ b/app/views/random_thoughts/index.json.jbuilder
@@ -2,10 +2,4 @@
 
 json.data @random_thoughts, partial: 'random_thought', as: :random_thought
 
-json.meta do
-  json.current_page @random_thoughts.current_page
-  json.next_page @random_thoughts.next_page
-  json.prev_page @random_thoughts.prev_page
-  json.total_pages @random_thoughts.total_pages
-  json.total_count RandomThought.count
-end
+json.partial! 'meta/meta', items: @random_thoughts, item_class: RandomThought

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.data @users, partial: 'user', as: :user, current_user: @current_user
+
+json.partial! 'meta/meta', items: @users, item_class: User

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   get  '/logout', to: 'authentication#logout', defaults: { format: 'json' }
 
   resources :random_thoughts, defaults: { format: 'json' }
-  resources :users, defaults: { format: 'json' }, only: %i[show create update destroy]
+  resources :users, defaults: { format: 'json' }, only: %i[index show create update destroy]
 
   mount Rswag::Api::Engine => '/api-docs'
   mount Rswag::Ui::Engine => '/api-docs'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,7 @@ require 'rspec/rails'
 require_relative 'support/factory_bot'
 
 require_relative 'support/helpers/api_helper'
+require_relative 'support/matchers/be_different_user_json'
 require_relative 'support/matchers/be_error_json'
 require_relative 'support/matchers/be_random_thought_json'
 require_relative 'support/matchers/be_same_user_json'

--- a/spec/requests/get_user_spec.rb
+++ b/spec/requests/get_user_spec.rb
@@ -37,12 +37,8 @@ RSpec.describe 'get /user/{id}' do
         get_user(different_user, valid_auth_jwt)
       end
 
-      it 'only returns "display_name"' do
-        expect(json_body.keys).to eql(['display_name'])
-      end
-
-      it 'returns "display_name": display_name of requested user' do
-        expect(json_body['display_name']).to eql(different_user.display_name)
+      it 'returns different user JSON with correct values' do
+        expect(json_body).to be_different_user_json(different_user)
       end
     end
 

--- a/spec/requests/get_users_spec.rb
+++ b/spec/requests/get_users_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+require_relative '../support/helpers/jwt_helper'
+require_relative '../support/shared_examples/jwt_authorization'
+
+require_relative '../support/helpers/pagination_helper'
+require_relative '../support/shared_contexts/when_at_least_three_pages'
+require_relative '../support/shared_contexts/when_first_paginated_page'
+require_relative '../support/shared_contexts/when_last_paginated_page'
+require_relative '../support/shared_contexts/when_middle_paginated_page'
+require_relative '../support/shared_examples/empty_paginated_page'
+require_relative '../support/shared_examples/pagination_meta_data'
+
+RSpec.describe 'get /users/' do
+  include JwtHelper
+  include PaginationHelper
+
+  let!(:user) { create(:user) }
+
+  describe 'authorization' do
+    let(:request_without_jwt) { get users_path, params: {} }
+    let(:request_with_jwt) { get_users(jwt) }
+
+    it_behaves_like 'jwt_authorization'
+  end
+
+  # TODO: Probs make this deterministic so user is on page
+  context 'when there are users' do
+    let(:page) { rand(1..pages) }
+
+    include_context 'when at least three pages', User, :user
+
+    before do
+      # get random_thoughts_path({ page: })
+      get_users(jwt, page)
+    end
+
+    # TODO: Not sure about this yet
+    describe 'returned "data" body' do
+      it 'contains correct user information display for page' do
+        all_returned = data_body
+        User.page(page).each do |user_on_page|
+          returned = all_returned.shift
+          if user_on_page == user
+            expect(returned).to be_same_user_json(user)
+          else
+            expect(returned).to be_different_user_json(user_on_page)
+          end
+        end
+      end
+
+      # TODO: Implement different user display except for user
+
+      # it 'contains all correct random thoughts for page' do
+      #   all_returned = data_body
+      #   RandomThought.page(page).each do |random_thought|
+      #     returned = all_returned.shift
+      #     expect(returned).to be_random_thought_json(random_thought)
+      #   end
+      # end
+    end
+
+    it_behaves_like 'pagination_meta_data'
+  end
+
+  describe 'first page' do
+    subject(:first_page_request) { get random_thoughts_path({ page: 1 }) }
+
+    include_context 'when first paginated page', RandomThought, :random_thought
+  end
+
+  describe 'last page' do
+    subject(:last_page_request) { get random_thoughts_path({ page: pages }) }
+
+    include_context 'when last paginated page', RandomThought, :random_thought
+  end
+
+  describe 'middle page' do
+    subject(:middle_page_request) { get random_thoughts_path({ page: middle_page }) }
+
+    let(:middle_page) { 2 }
+
+    include_context 'when middle paginated page', RandomThought, :random_thought
+  end
+
+  context 'when there are no random thoughts' do
+    subject(:any_page_request) { get random_thoughts_path({ page: any_page }) }
+
+    let(:any_page) { 1 }
+
+    it_behaves_like 'empty_paginated page'
+  end
+
+  private
+
+  def get_users(jwt, page: false)
+    # TODO: Refactor this and do the same in get_random_thoughts
+    if page
+     get users_path({ page: }), headers: authorization_header(jwt)
+    else
+      get users_path, headers: authorization_header(jwt)
+    end
+  end
+end

--- a/spec/requests/get_users_spec.rb
+++ b/spec/requests/get_users_spec.rb
@@ -3,13 +3,12 @@
 require 'rails_helper'
 
 require_relative '../support/helpers/jwt_helper'
-require_relative '../support/shared_examples/jwt_authorization'
-
 require_relative '../support/helpers/pagination_helper'
 require_relative '../support/shared_contexts/when_at_least_three_pages'
 require_relative '../support/shared_contexts/when_first_paginated_page'
 require_relative '../support/shared_contexts/when_last_paginated_page'
 require_relative '../support/shared_contexts/when_middle_paginated_page'
+require_relative '../support/shared_examples/jwt_authorization'
 require_relative '../support/shared_examples/empty_paginated_page'
 require_relative '../support/shared_examples/pagination_meta_data'
 
@@ -17,90 +16,83 @@ RSpec.describe 'get /users/' do
   include JwtHelper
   include PaginationHelper
 
-  let!(:user) { create(:user) }
+  let(:valid_auth_jwt) { valid_jwt(user) }
 
   describe 'authorization' do
+    let(:user) { create(:user) }
     let(:request_without_jwt) { get users_path, params: {} }
     let(:request_with_jwt) { get_users(jwt) }
 
     it_behaves_like 'jwt_authorization'
   end
 
-  # TODO: Probs make this deterministic so user is on page
-  context 'when there are users' do
+  # NOTE: Since this endpoint requires authorization, there
+  #       is always at least the one authorized user
+  describe 'any page' do
     let(:page) { rand(1..pages) }
+    # Guarantee that the requesting user is always in page
+    let(:user) { User.page(page).first }
 
     include_context 'when at least three pages', User, :user
 
     before do
-      # get random_thoughts_path({ page: })
-      get_users(jwt, page)
+      get_users(valid_auth_jwt, page:)
     end
 
-    # TODO: Not sure about this yet
     describe 'returned "data" body' do
       it 'contains correct user information display for page' do
         all_returned = data_body
-        User.page(page).each do |user_on_page|
+        User.page(page).each do |page_user|
           returned = all_returned.shift
-          if user_on_page == user
-            expect(returned).to be_same_user_json(user)
-          else
-            expect(returned).to be_different_user_json(user_on_page)
-          end
+          expect_correct_same_or_different_user_json(returned, page_user, user)
         end
       end
-
-      # TODO: Implement different user display except for user
-
-      # it 'contains all correct random thoughts for page' do
-      #   all_returned = data_body
-      #   RandomThought.page(page).each do |random_thought|
-      #     returned = all_returned.shift
-      #     expect(returned).to be_random_thought_json(random_thought)
-      #   end
-      # end
     end
 
     it_behaves_like 'pagination_meta_data'
   end
 
   describe 'first page' do
-    subject(:first_page_request) { get random_thoughts_path({ page: 1 }) }
+    subject(:first_page_request) { get_users(valid_auth_jwt, page: first_page) }
 
-    include_context 'when first paginated page', RandomThought, :random_thought
+    let(:first_page) { 1 }
+    let(:user) { User.page(first_page).first }
+
+    include_context 'when first paginated page', User, :user
   end
 
   describe 'last page' do
-    subject(:last_page_request) { get random_thoughts_path({ page: pages }) }
+    subject(:last_page_request) { get_users(valid_auth_jwt, page: pages) }
 
-    include_context 'when last paginated page', RandomThought, :random_thought
+    let(:user) { User.page(pages).first }
+
+    include_context 'when last paginated page', User, :user
   end
 
   describe 'middle page' do
-    subject(:middle_page_request) { get random_thoughts_path({ page: middle_page }) }
+    subject(:middle_page_request) { get_users(valid_auth_jwt, page: middle_page) }
 
     let(:middle_page) { 2 }
+    let(:user) { User.page(middle_page).first }
 
-    include_context 'when middle paginated page', RandomThought, :random_thought
-  end
-
-  context 'when there are no random thoughts' do
-    subject(:any_page_request) { get random_thoughts_path({ page: any_page }) }
-
-    let(:any_page) { 1 }
-
-    it_behaves_like 'empty_paginated page'
+    include_context 'when middle paginated page', User, :user
   end
 
   private
 
   def get_users(jwt, page: false)
-    # TODO: Refactor this and do the same in get_random_thoughts
     if page
-     get users_path({ page: }), headers: authorization_header(jwt)
+      get users_path({ page: }), headers: authorization_header(jwt)
     else
       get users_path, headers: authorization_header(jwt)
+    end
+  end
+
+  def expect_correct_same_or_different_user_json(returned, page_user, user)
+    if page_user == user
+      expect(returned).to be_same_user_json(user)
+    else
+      expect(returned).to be_different_user_json(page_user)
     end
   end
 end

--- a/spec/requests/swagger_users_spec.rb
+++ b/spec/requests/swagger_users_spec.rb
@@ -30,6 +30,31 @@ RSpec.describe 'users' do
   # rubocop:enable RSpec/VariableName
 
   path '/users' do
+    get('list users') do
+      consumes 'application/json'
+      produces 'application/json'
+      security [bearer: []]
+      parameter name: 'page',
+                in: :query,
+                type: :integer,
+                description: 'page number',
+                required: false
+
+      let(:user) { create(:user) }
+
+      response(200, 'successful') do
+        let(:jwt) { valid_jwt(user) }
+        schema '$ref' => '#/components/schemas/paginated_users'
+        run_test!
+      end
+
+      response(401, 'unauthorized') do
+        let(:jwt) { invalid_signature_jwt(user) }
+        it_behaves_like 'unauthorized schema', 'Signature verification failed'
+        run_test!
+      end
+    end
+
     post('create user') do
       consumes 'application/json'
       produces 'application/json'

--- a/spec/support/helpers/pagination_helper.rb
+++ b/spec/support/helpers/pagination_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PaginationHelper
+  # NOTE: This uses APIHelper
+
+  def data_body
+    json_body['data']
+  end
+
+  def metadata_body
+    json_body['meta']
+  end
+end

--- a/spec/support/matchers/be_different_user_json.rb
+++ b/spec/support/matchers/be_different_user_json.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Custom RSpec Matcher to ensure
+# only expected attributes
+# and their correct values
+# for a user JSON response
+# when the current user
+# is not the requested user
+module BeDifferentUserJson
+  class BeDifferentUserJson
+    def initialize(expected_user)
+      @expected_user = expected_user
+    end
+
+    def matches?(actual)
+      @actual = actual
+
+      # Ensure only expected attributes are present and match values
+      @actual.keys == only_allowed_attributes &&
+        @actual['display_name'] == @expected_user.display_name
+    end
+
+    def failure_message
+      "expected that actual: #{pretty(@actual)} would match " \
+        "expected: #{pretty(matched_expected)}"
+    end
+
+    def failure_message_when_negated
+      "expected that actual: #{pretty(@actual)} would not match " \
+        "expected: #{pretty(matched_expected)}"
+    end
+
+    private
+
+    def only_allowed_attributes
+      ['display_name']
+    end
+
+    def pretty(json)
+      JSON.pretty_generate(json)
+    end
+
+    def matched_expected
+      @expected_user.attributes.slice(*only_allowed_attributes)
+    end
+  end
+
+  def be_different_user_json(expected_user)
+    BeDifferentUserJson.new(expected_user)
+  end
+end
+
+# Include the custom matcher in RSpec
+RSpec.configure do |config|
+  config.include BeDifferentUserJson
+end

--- a/spec/support/shared_contexts/when_at_least_three_pages.rb
+++ b/spec/support/shared_contexts/when_at_least_three_pages.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'when at least three pages' do |class_under_test, factory_name|
+  let(:pages) { 3 }
+  let(:per_page) { class_under_test.page.limit_value }
+  let(:num_items) { (per_page * (pages - 1)) + 1 }
+
+  before do
+    create_list(factory_name, num_items)
+  end
+end

--- a/spec/support/shared_contexts/when_first_paginated_page.rb
+++ b/spec/support/shared_contexts/when_first_paginated_page.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative './when_at_least_three_pages'
+
+RSpec.shared_context 'when first paginated page' do |class_under_test, factory_name|
+  include_context 'when at least three pages', class_under_test, factory_name
+
+  before do
+    first_page_request
+  end
+
+  it 'returned "meta" body contains "prev_page": nil' do
+    expect(metadata_body['prev_page']).to be_nil
+  end
+end

--- a/spec/support/shared_contexts/when_last_paginated_page.rb
+++ b/spec/support/shared_contexts/when_last_paginated_page.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative './when_at_least_three_pages'
+
+RSpec.shared_context 'when last paginated page' do |class_under_test, factory_name|
+  include_context 'when at least three pages', class_under_test, factory_name
+
+  before do
+    last_page_request
+  end
+
+  it 'returned "meta" body contains "next_page": nil' do
+    expect(metadata_body['next_page']).to be_nil
+  end
+end

--- a/spec/support/shared_contexts/when_middle_paginated_page.rb
+++ b/spec/support/shared_contexts/when_middle_paginated_page.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative './when_at_least_three_pages'
+
+RSpec.shared_context 'when middle paginated page' do |class_under_test, factory_name|
+  include_context 'when at least three pages', class_under_test, factory_name
+
+  before do
+    middle_page_request
+  end
+
+  it 'contains correct "next_page"' do
+    expect(metadata_body['next_page']).to be(middle_page + 1)
+  end
+
+  it 'contains correct "prev_page"' do
+    expect(metadata_body['prev_page']).to be(middle_page - 1)
+  end
+end

--- a/spec/support/shared_examples/empty_paginated_page.rb
+++ b/spec/support/shared_examples/empty_paginated_page.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'empty_paginated page' do
+  before do
+    any_page_request
+  end
+
+  describe 'returned "data" body' do
+    it 'contains [] (empty array)' do
+      expect(data_body).to eql([])
+    end
+  end
+
+  describe 'returned "meta" body' do
+    it 'contains requested page in "current_page"' do
+      expect(metadata_body['current_page']).to eql(any_page)
+    end
+
+    it 'contains "next_page": nil' do
+      expect(metadata_body['next_page']).to be_nil
+    end
+
+    it 'contains "prev_page": nil' do
+      expect(metadata_body['prev_page']).to be_nil
+    end
+
+    it 'contains "total_pages": 0' do
+      expect(metadata_body['total_pages']).to be(0)
+    end
+
+    it 'contains "total_count": 0' do
+      expect(metadata_body['total_count']).to be(0)
+    end
+  end
+end

--- a/spec/support/shared_examples/pagination_meta_data.rb
+++ b/spec/support/shared_examples/pagination_meta_data.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'pagination_meta_data' do
+  it 'contains requested page in "current_page"' do
+    expect(metadata_body['current_page']).to eql(page)
+  end
+
+  it 'contains correct number in "total_pages"' do
+    expect(metadata_body['total_pages']).to be(pages)
+  end
+
+  it 'contains correct total in "total_count"' do
+    expect(metadata_body['total_count']).to be(num_items)
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -111,6 +111,17 @@ RSpec.configure do |config|
               user: { '$ref' => '#/components/schemas/new_user' }
             }
           },
+          # Handles same and different user responses
+          # Same user has all properties, different only has display_name
+          user_response: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer' },
+              email: { type: 'string', minLength: 1, maxLength: 254 },
+              display_name: { type: 'string', minLength: 1 }
+            },
+            required: %w[display_name]
+          },
           same_user_response: {
             type: 'object',
             properties: {
@@ -142,6 +153,19 @@ RSpec.configure do |config|
               user: { '$ref' => '#/components/schemas/updated_user' }
             },
             required: %w[user]
+          },
+          paginated_users: {
+            type: 'object',
+            properties: {
+              data: {
+                type: :array,
+                items: { '$ref' => '#/components/schemas/user_response' }
+              },
+              meta: {
+                '$ref' => '#/components/schemas/pagination'
+              }
+            },
+            required: %w[data meta]
           },
           login_credentials: {
             type: 'object',

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -235,6 +235,36 @@ paths:
               schema:
                 "$ref": "#/components/schemas/error"
   "/users":
+    get:
+      summary: list users
+      security:
+      - bearer: []
+      parameters:
+      - name: page
+        in: query
+        description: page number
+        required: false
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/paginated_users"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              examples:
+                unauthorized:
+                  value:
+                    status: 401
+                    error: unauthorized
+                    message: Signature verification failed
+              schema:
+                "$ref": "#/components/schemas/error"
     post:
       summary: create user
       parameters: []
@@ -539,6 +569,20 @@ components:
       properties:
         user:
           "$ref": "#/components/schemas/new_user"
+    user_response:
+      type: object
+      properties:
+        id:
+          type: integer
+        email:
+          type: string
+          minLength: 1
+          maxLength: 254
+        display_name:
+          type: string
+          minLength: 1
+      required:
+      - display_name
     same_user_response:
       type: object
       properties:
@@ -586,6 +630,18 @@ components:
           "$ref": "#/components/schemas/updated_user"
       required:
       - user
+    paginated_users:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/user_response"
+        meta:
+          "$ref": "#/components/schemas/pagination"
+      required:
+      - data
+      - meta
     login_credentials:
       type: object
       properties:


### PR DESCRIPTION
# What
This changeset adds new functionality to get all Users with pagination through the new API endpoint`get /users` with the `page` query parameter (`get /users?page=23`).

Specifically...
* Adds `users_controller#index`
* Adds Swagger File specification (tests) for `get /users`
* Adds functional tests for `get /users`
* Refactoring of code under development and test
* Update README with new endpoint

# Why
This adds ability and Swagger specification to get all created Users in a paginated manner and ensure this ability throughout changes with automated tests.

# Change Impact Analysis and Testing

New functionality is verified by...
- [x] Running new automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Refactored existing functionality is verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Updated documentation is verified by...
- [x] Manual inspection of README