### PR TITLE
Ensure Data Integrity by Adding User Email Maximum Length Database Constraint

### DIFF
--- a/db/migrate/20230216195842_create_users.rb
+++ b/db/migrate/20230216195842_create_users.rb
@@ -3,6 +3,8 @@ class CreateUsers < ActiveRecord::Migration[7.0]
     enable_extension(:citext)
     create_table :users do |t|
       t.citext :email, null: false, index: { unique: true }
+      t.check_constraint '(length(email) < 255)', name: 'email_length_check'
+
       t.string :display_name, null: false
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,6 +31,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_02_151754) do
     t.string "password_digest"
     t.bigint "authorization_min", default: -9223372036854775808
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.check_constraint "length(email::text) < 255", name: "email_length_check"
   end
 
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,6 +7,11 @@ FactoryBot.define do
     password { Faker::Internet.unique.password }
     password_confirmation { password }
 
+    trait :email_255_chars do
+      domain = '@test.com'
+      email { "#{Faker::Lorem.characters(number: (255 - domain.length))}#{domain}" }
+    end
+
     trait :empty_email do
       email { '' }
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe User do
+  describe 'database constraints' do
+    describe 'email' do
+      it 'raises db error when email length greater than 254 characters' do
+        user = build(:user, :email_255_chars)
+        expect { user.save!(validate: false) }.to raise_error(ActiveRecord::StatementInvalid, /PG::CheckViolation/)
+      end
+    end
+  end
+
   describe 'validations' do
     describe 'email' do
       let(:valid_but_rejected_email) { '"Some spaces! And @ sign too!" @some.server.com' }


### PR DESCRIPTION
# What
This data-integrity-only changeset adds a constraint at the (PostgreSQL) database level to ensure `User` `email` addresses do not exceed 254 characters in accordance to the email address standard.  An automated test and `:user` factory trait for this condition is also added.  

# Why
Although this maximum length was enforced in the application using a validation, it was not enforced at the database itself allowing for potential data integrity issues if a `User` record would be added directly to the database without going through the application's `User` model validations.

# Change Impact Analysis and Testing

> Note that since this application is currently development only, this constraint can be added directly to the create table migration.  If this application was in production a different [two-step](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-NOTES) method would need to be used.

New database constraint verified by...
- [x] Test-Driven Development and success passing of added automated test (manual and CI)

No regressions in functionality verified by...
- [x] Running existing automated tests (CI)

