### PR TITLE
Enhance Security by Adding Authorization to Create Random Thought

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ This API contains the following endpoints...
       }
     }
     ```
+    > **Requires** Authorization JWT from login
+    > in request header
 
   * **Update** random thought {id}: `patch /random_thoughts/{id}`
     with Request Body...

--- a/app/controllers/random_thoughts_controller.rb
+++ b/app/controllers/random_thoughts_controller.rb
@@ -2,6 +2,7 @@
 
 # Implements CRUD operations for RandomThought
 class RandomThoughtsController < ApplicationController
+  before_action :authorize_request, only: %i[create]
   before_action :find_random_thought, only: %i[show update destroy]
 
   def index

--- a/spec/requests/create_random_thought_spec.rb
+++ b/spec/requests/create_random_thought_spec.rb
@@ -1,20 +1,33 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+
+require_relative '../support/helpers/jwt_helper'
 require_relative '../support/helpers/random_thought_helper'
 require_relative '../support/shared_examples/bad_request_response'
 require_relative '../support/shared_examples/is_created_from_request'
 require_relative '../support/shared_examples/is_not_created_from_request'
+require_relative '../support/shared_examples/jwt_authorization'
 require_relative '../support/shared_examples/random_thought_response'
 require_relative '../support/shared_examples/unprocessable_entity_response'
 
 RSpec.describe 'post /random_thoughts/' do
+  include JwtHelper
   include RandomThoughtHelper
 
-  context 'when valid create request' do
-    subject(:request) { post_random_thought(random_thought) }
+  let!(:user) { create(:user) }
+  let(:valid_auth_jwt) { valid_jwt(user) }
+  let(:random_thought) { build(:random_thought) }
 
-    let(:random_thought) { build(:random_thought) }
+  describe 'authorization' do
+    let(:request_without_jwt) { raw_post_random_thought(build_random_thought_body(random_thought)) }
+    let(:request_with_jwt) { post_random_thought(random_thought, jwt) }
+
+    it_behaves_like 'jwt_authorization'
+  end
+
+  context 'when valid create request' do
+    subject(:request) { post_random_thought(random_thought, valid_auth_jwt) }
 
     before do |example|
       request unless example.metadata[:skip_before]
@@ -26,7 +39,7 @@ RSpec.describe 'post /random_thoughts/' do
   end
 
   context 'when parameters are missing in create request' do
-    subject(:request) { post random_thoughts_path, params: empty_json_body }
+    subject(:request) { raw_post_random_thought(empty_json_body, headers: authorization_header(valid_auth_jwt)) }
 
     before do |example|
       request unless example.metadata[:skip_before]
@@ -40,7 +53,7 @@ RSpec.describe 'post /random_thoughts/' do
   # TODO: Testing invalid json does not seem to be possible
 
   context 'when validations fail for create request' do
-    subject(:request) { post_random_thought(not_valid) }
+    subject(:request) { post_random_thought(not_valid, valid_auth_jwt) }
 
     let(:not_valid) { build(:random_thought, :empty) }
 
@@ -55,7 +68,15 @@ RSpec.describe 'post /random_thoughts/' do
 
   private
 
-  def post_random_thought(random_thought)
-    post random_thoughts_path, params: build_random_thought_body(random_thought)
+  def post_random_thought(random_thought, jwt)
+    raw_post_random_thought(build_random_thought_body(random_thought), headers: authorization_header(jwt))
+  end
+
+  def raw_post_random_thought(params, headers: false)
+    if headers
+      post random_thoughts_path, params:, headers:
+    else
+      post random_thoughts_path, params:
+    end
   end
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -84,6 +84,8 @@ paths:
                 "$ref": "#/components/schemas/paginated_random_thoughts"
     post:
       summary: create random_thought
+      security:
+      - bearer: []
       parameters: []
       responses:
         '201':
@@ -107,6 +109,18 @@ paths:
                     status: 400
                     error: bad_request
                     message: Error occurred while parsing request parameters
+              schema:
+                "$ref": "#/components/schemas/error"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              examples:
+                unauthorized:
+                  value:
+                    status: 401
+                    error: unauthorized
+                    message: Signature verification failed
               schema:
                 "$ref": "#/components/schemas/error"
         '422':


### PR DESCRIPTION
# What
This changeset adds authorization requirement to the create Random Thought (`post /random_thoughts`) route.

# Why
This changeset enhances security and prepares for associating a Random Thought with a user.

# Change Impact Analysis and Testing
This change is limited to and only impacts the `random_thoughts#create` action and appropriate tests as well as a README update to create Random Thought endpoint mentioning the added authorization requirement. 

New added authorization verified by...
- [x] Running new automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

No regressions to existing functionality is verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Updated documentation is verified by...
- [x] Manual inspection of README
