### PR TITLE
Enhance Security by Adding Authorization to Delete Random Thought

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ This API contains the following endpoints...
     ```
 
   * **Delete** random thought {id}: `delete /random_thoughts/{id}`
+    > **Requires** Authorization JWT from login
+    > in request header
 
 ## Development
 This project can be developed using the supplied basic,

--- a/app/controllers/random_thoughts_controller.rb
+++ b/app/controllers/random_thoughts_controller.rb
@@ -2,7 +2,7 @@
 
 # Implements CRUD operations for RandomThought
 class RandomThoughtsController < ApplicationController
-  before_action :authorize_request, only: %i[create]
+  before_action :authorize_request, only: %i[create destroy]
   before_action :find_random_thought, only: %i[show update destroy]
 
   def index

--- a/spec/requests/delete_random_thought_spec.rb
+++ b/spec/requests/delete_random_thought_spec.rb
@@ -1,18 +1,33 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+
+require_relative '../support/helpers/jwt_helper'
 require_relative '../support/shared_examples/is_deleted_from_request'
+require_relative '../support/shared_examples/jwt_authorization'
 require_relative '../support/shared_examples/not_found_response'
 require_relative '../support/shared_examples/random_thought_response'
 
 RSpec.describe 'delete /random_thoughts/{id}' do
+  include JwtHelper
+
+  let(:user) { create(:user) }
+  let(:valid_auth_jwt) { valid_jwt(user) }
+  let(:random_thought) { create(:random_thought) }
+
+  describe 'authorization' do
+    let(:request_without_jwt) { delete random_thought_path(random_thought) }
+    let(:request_with_jwt) { delete_random_thought(random_thought, jwt) }
+
+    it_behaves_like 'jwt_authorization'
+  end
+
   context 'when {id} exists' do
-    let(:random_thought) { create(:random_thought) }
     # Ensure object to delete is created before expect block in 'is deleted...'
     # rubocop:disable RSpec/LetSetup
     let!(:object_to_delete) { random_thought }
     # rubocop:enable RSpec/LetSetup
-    let(:delete_request) { delete_random_thought(random_thought) }
+    let(:delete_request) { delete_random_thought(random_thought, valid_auth_jwt) }
 
     before do |example|
       delete_request unless example.metadata[:skip_before]
@@ -31,7 +46,7 @@ RSpec.describe 'delete /random_thoughts/{id}' do
     let(:does_not_exist) { build(:random_thought).id = 0 }
 
     before do
-      delete_random_thought(does_not_exist)
+      delete_random_thought(does_not_exist, valid_auth_jwt)
     end
 
     it_behaves_like 'not_found response'
@@ -39,7 +54,7 @@ RSpec.describe 'delete /random_thoughts/{id}' do
 
   private
 
-  def delete_random_thought(random_thought)
-    delete random_thought_path(random_thought)
+  def delete_random_thought(random_thought, jwt)
+    delete random_thought_path(random_thought), headers: authorization_header(jwt)
   end
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -229,6 +229,8 @@ paths:
               "$ref": "#/components/schemas/update_random_thought"
     delete:
       summary: delete random_thought
+      security:
+      - bearer: []
       responses:
         '200':
           description: successful
@@ -236,6 +238,18 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/random_thought_response"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              examples:
+                unauthorized:
+                  value:
+                    status: 401
+                    error: unauthorized
+                    message: Signature verification failed
+              schema:
+                "$ref": "#/components/schemas/error"
         '404':
           description: not found
           content:


### PR DESCRIPTION
# What
This changeset adds authorization requirement to the delete Random Thought (`delete /random_thoughts/{id}`) route.

# Why
This changeset enhances security and prepares for associating a Random Thought with a user.

# Change Impact Analysis and Testing
This change is limited to and only impacts the `random_thoughts#destroy` action and appropriate tests as well as a README update to delete Random Thought endpoint mentioning the added authorization requirement. 

New added authorization verified by...
- [x] Running new automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

No regressions to existing functionality is verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Updated documentation is verified by...
- [x] Manual inspection of README
