### PR TITLE
Enhance Security by Adding Authorization to Update Random Thought

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ This API contains the following endpoints...
       }
     }
     ```
+    > **Requires** Authorization JWT from login
+    > in request header
 
   * **Delete** random thought {id}: `delete /random_thoughts/{id}`
     > **Requires** Authorization JWT from login

--- a/app/controllers/random_thoughts_controller.rb
+++ b/app/controllers/random_thoughts_controller.rb
@@ -2,7 +2,7 @@
 
 # Implements CRUD operations for RandomThought
 class RandomThoughtsController < ApplicationController
-  before_action :authorize_request, only: %i[create destroy]
+  before_action :authorize_request, only: %i[create update destroy]
   before_action :find_random_thought, only: %i[show update destroy]
 
   def index

--- a/spec/requests/swagger_random_thoughts_spec.rb
+++ b/spec/requests/swagger_random_thoughts_spec.rb
@@ -105,12 +105,14 @@ RSpec.describe 'random_thoughts' do
     patch('update random_thought') do
       consumes 'application/json'
       produces 'application/json'
+      security [bearer: []]
       parameter name: :update,
                 in: :body,
                 schema: { '$ref' => '#/components/schemas/update_random_thought' }
 
+      let(:update) { build_random_thought_body(build(:random_thought)) }
+
       response(200, 'successful') do
-        let(:update) { build_random_thought_body(build(:random_thought)) }
         schema '$ref' => '#/components/schemas/random_thought_response'
         run_test!
       end
@@ -121,8 +123,13 @@ RSpec.describe 'random_thoughts' do
         run_test!
       end
 
+      response(401, 'unauthorized') do
+        let(:jwt) { invalid_signature_jwt(user) }
+        it_behaves_like 'unauthorized schema', 'Signature verification failed'
+        run_test!
+      end
+
       response(404, 'not found') do
-        let(:update) { build_random_thought_body(build(:random_thought)) }
         let(:id) { 0 }
         it_behaves_like 'not found schema', RandomThoughtMessage.not_found
         run_test!

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -172,6 +172,8 @@ paths:
                 "$ref": "#/components/schemas/error"
     patch:
       summary: update random_thought
+      security:
+      - bearer: []
       parameters: []
       responses:
         '200':
@@ -195,6 +197,18 @@ paths:
                     status: 400
                     error: bad_request
                     message: Error occurred while parsing request parameters
+              schema:
+                "$ref": "#/components/schemas/error"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              examples:
+                unauthorized:
+                  value:
+                    status: 401
+                    error: unauthorized
+                    message: Signature verification failed
               schema:
                 "$ref": "#/components/schemas/error"
         '404':


### PR DESCRIPTION
# What
This changeset adds authorization requirement to the update Random Thought (`patch /random_thoughts/{id}`) route.

# Why
This changeset enhances security and prepares for associating a Random Thought with a user.

# Change Impact Analysis and Testing
This change is limited to and only impacts the `random_thoughts#update` action and appropriate tests as well as a README update to delete Random Thought endpoint mentioning the added authorization requirement. 

New added authorization verified by...
- [x] Running new automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

No regressions to existing functionality is verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Updated documentation is verified by...
- [x] Manual inspection of README
