### PR TITLE
Make Random Thought Belong To User

### DIFF
--- a/app/controllers/random_thoughts_controller.rb
+++ b/app/controllers/random_thoughts_controller.rb
@@ -14,7 +14,7 @@ class RandomThoughtsController < ApplicationController
   end
 
   def create
-    @random_thought = RandomThought.new(random_thought_params)
+    @random_thought = @current_user.random_thoughts.build(random_thought_params)
     if @random_thought.save
       render_show_response(:created)
     else

--- a/app/models/random_thought.rb
+++ b/app/models/random_thought.rb
@@ -2,6 +2,8 @@
 
 # Represents someone's random thought
 class RandomThought < ApplicationRecord
+  belongs_to :user
+
   default_scope -> { order(created_at: :desc) }
 
   validates :thought, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@
 class User < ApplicationRecord
   PASSWORD_MIN_LENGTH = 8
 
+  has_many :random_thoughts, dependent: :destroy
+
   validates :email, presence: true, uniqueness: true,
                     # NOTE: citext (db) does not support max length constraint
                     length: {

--- a/db/migrate/20230315141807_add_user_to_random_thought.rb
+++ b/db/migrate/20230315141807_add_user_to_random_thought.rb
@@ -1,0 +1,5 @@
+class AddUserToRandomThought < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :random_thoughts, :user, null: false, foreign_key: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_02_151754) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_15_141807) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -20,7 +20,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_02_151754) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["created_at"], name: "index_random_thoughts_on_created_at"
+    t.index ["user_id"], name: "index_random_thoughts_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -34,4 +36,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_02_151754) do
     t.check_constraint "length(email::text) < 255", name: "email_length_check"
   end
 
+  add_foreign_key "random_thoughts", "users"
 end

--- a/spec/factories/random_thoughts.rb
+++ b/spec/factories/random_thoughts.rb
@@ -2,6 +2,8 @@
 
 FactoryBot.define do
   factory :random_thought do
+    association :user
+
     thought { Faker::Lorem.sentence }
     name { Faker::Name.name }
 

--- a/spec/models/random_thought_spec.rb
+++ b/spec/models/random_thought_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe RandomThought do
+  describe 'relationships' do
+    it { is_expected.to belong_to(:user) }
+  end
+
   describe 'default scope' do
     it 'returns most recent first' do
       create_list(:random_thought, 20)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe User do
     end
   end
 
+  describe 'relationships' do
+    it { is_expected.to have_many(:random_thoughts).dependent(:destroy) }
+  end
+
   describe 'validations' do
     describe 'email' do
       let(:valid_but_rejected_email) { '"Some spaces! And @ sign too!" @some.server.com' }


### PR DESCRIPTION
# What
This changeset is the first in associating RandomThoughts with a particular user.  This changeset adds the bidirectional association...
-  User `has_many` RandomThoughts
- RandomThought `belongs_to` User

A `dependent: :destroy` operation is added to the User `has_many` RandomThoughts association so that when a User is deleted all of that user's RandomThoughts are deleted as well. 

This changeset changes the `random_thoughts#create` controller action to associate the newly-created RandomThought with the current user as identified in the authorization JWT.

# Why
This is the first step in the final vision for this application where RandomThoughts are associated with a User instead of existing independently.

# Change Impact Analysis and Testing
This changeset changes the independence of RandomThoughts and their lifecycle to be dependent on a User and its lifecycle.  There is no change to user interaction since create random thought already requires authorization which is used to associate the new RandomThought with the currently authorized user. 

New association of a RandomThought to a User is verified by...
- [x] New `User` and `Random Thought` model automated tests (CI)

No Regressions to existing functionality is verified by...
- [x] Existing automated tests (CI)