### PR TITLE
Enhance Security by Restricting Update RandomThought to Creating User

### DIFF
--- a/app/controllers/random_thoughts_controller.rb
+++ b/app/controllers/random_thoughts_controller.rb
@@ -4,8 +4,8 @@
 class RandomThoughtsController < ApplicationController
   before_action :authorize_request, only: %i[create update destroy]
   before_action :find_random_thought, only: %i[show update destroy]
-  before_action :find_random_thought_user, only: %i[destroy]
-  before_action :authorize_current_user, only: %i[destroy]
+  before_action :find_random_thought_user, only: %i[update destroy]
+  before_action :authorize_current_user, only: %i[update destroy]
 
   def index
     @random_thoughts = RandomThought.page(params[:page])

--- a/spec/requests/delete_random_thought_spec.rb
+++ b/spec/requests/delete_random_thought_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'delete /random_thoughts/{id}' do
   let!(:user) { create(:user) }
   let(:valid_auth_jwt) { valid_jwt(user) }
   # RandomThought is created before authorization
+  # and associate it with the user
   let!(:random_thought) { create(:random_thought, user:) }
 
   describe 'authorization' do

--- a/spec/requests/swagger_random_thoughts_spec.rb
+++ b/spec/requests/swagger_random_thoughts_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe 'random_thoughts' do
   path '/random_thoughts/{id}' do
     parameter name: 'id', in: :path, type: :string, description: 'id'
 
+    # Create RandomThought associated with User
     let(:id) { create(:random_thought, user:).id }
 
     get('show random_thought') do


### PR DESCRIPTION
# What
This changeset adds the restriction that only the user that created the RandomThought can update it (i.e. the associated User).

# Why
Now that a RandomThoughts is associated with a User - the User that created the RandomThought, this changeset enhances security by only allowing the User associated with the RandomThought to update it.

# Change Impact Analysis and Testing

New update restriction verified by...
- [x] Running new added automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

No regressions to existing functionality is verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI