### PR TITLE
Add Mood Attribute to RandomThought

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ that implements a random thought in JSON format...
 ```json
 {
   "thought": "A random thought",
-  "name": "The Thinker's Name"
+  "name": "The thinker's name",
+  "mood": "The thinker's mood leading to the thought"
 }
 ```
 
@@ -92,7 +93,8 @@ This API contains the following endpoints...
     {
       "random_thought": {
         "thought": "string",
-        "name": "string"
+        "name": "string",
+        "mood": "string"
       }
     }
     ```
@@ -105,7 +107,8 @@ This API contains the following endpoints...
     {
       "random_thought": {
         "thought": "string",
-        "name": "string"
+        "name": "string",
+        "mood": "string"
       }
     }
     ```

--- a/app/controllers/random_thoughts_controller.rb
+++ b/app/controllers/random_thoughts_controller.rb
@@ -42,7 +42,7 @@ class RandomThoughtsController < ApplicationController
   private
 
   def random_thought_params
-    params.required(:random_thought).permit(:thought, :name)
+    params.required(:random_thought).permit(:thought, :name, :mood)
   end
 
   def find_random_thought

--- a/app/models/random_thought.rb
+++ b/app/models/random_thought.rb
@@ -8,4 +8,6 @@ class RandomThought < ApplicationRecord
 
   validates :thought, presence: true
   validates :name, presence: true
+  validates :mood, presence: true
+
 end

--- a/app/views/random_thoughts/_random_thought.json.jbuilder
+++ b/app/views/random_thoughts/_random_thought.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-json.call(random_thought, :id, :thought, :name)
+json.call(random_thought, :id, :thought, :name, :mood)

--- a/db/migrate/20230316154729_add_mood_to_random_thoughts.rb
+++ b/db/migrate/20230316154729_add_mood_to_random_thoughts.rb
@@ -1,0 +1,5 @@
+class AddMoodToRandomThoughts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :random_thoughts, :mood, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_15_141807) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_16_154729) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_15_141807) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.string "mood", null: false
     t.index ["created_at"], name: "index_random_thoughts_on_created_at"
     t.index ["user_id"], name: "index_random_thoughts_on_user_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,4 +7,5 @@ first_user = User.create!(email: 'qhound@thisisfine.com', display_name: 'Questio
 User.create!(email: 'user@example.com', display_name: 'Ann User',
              password: 'password', password_confirmation: 'password')
 
-RandomThought.create!(thought: 'This is fine', name: 'Question Hound', user: first_user)
+RandomThought.create!(thought: 'This is fine', name: 'Question Hound',
+                      mood: 'Fiery', user: first_user)

--- a/spec/factories/random_thoughts.rb
+++ b/spec/factories/random_thoughts.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
 
     thought { Faker::Lorem.sentence }
     name { Faker::Name.name }
+    mood { Faker::Lorem.sentence }
 
     trait :empty_thought do
       thought { '' }
@@ -15,9 +16,14 @@ FactoryBot.define do
       name { '' }
     end
 
+    trait :empty_mood do
+      mood { '' }
+    end
+
     trait :empty do
       empty_thought
       empty_name
+      empty_mood
     end
   end
 end

--- a/spec/models/random_thought_spec.rb
+++ b/spec/models/random_thought_spec.rb
@@ -18,5 +18,6 @@ RSpec.describe RandomThought do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:thought) }
     it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:mood) }
   end
 end

--- a/spec/requests/update_random_thought_spec.rb
+++ b/spec/requests/update_random_thought_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe 'patch /random_thoughts/{id}' do
         expect(random_thought.reload.name).to eql(random_thought_update.name)
       end
 
+      it 'updates mood when supplied' do
+        just_mood = random_thought_update_just_keys(update, 'mood')
+        patch_random_thought(random_thought, valid_auth_jwt, just_mood)
+        expect(random_thought.reload.mood).to eql(random_thought_update.mood)
+      end
+
       it 'returns "id": id' do
         patch_random_thought(random_thought, valid_auth_jwt, update)
         expect(json_body['id']).to eql(random_thought.id)

--- a/spec/support/helpers/random_thought_helper.rb
+++ b/spec/support/helpers/random_thought_helper.rb
@@ -2,7 +2,7 @@
 
 module RandomThoughtHelper
   def build_random_thought_body(random_thought)
-    body = random_thought.attributes.slice('thought', 'name')
+    body = random_thought.attributes.slice('thought', 'name', 'mood')
     { random_thought: body }
   end
 end

--- a/spec/support/matchers/be_random_thought_json.rb
+++ b/spec/support/matchers/be_random_thought_json.rb
@@ -13,7 +13,8 @@ module BeRandomThoughtJson
       @actual = actual
 
       @actual['thought'] == @expected_thought.thought &&
-        @actual['name'] == @expected_thought.name
+        @actual['name'] == @expected_thought.name &&
+        @actual['mood'] == @expected_thought.mood
     end
 
     def failure_message
@@ -33,7 +34,7 @@ module BeRandomThoughtJson
     end
 
     def matched_expected
-      @expected_thought.attributes.slice('id', 'thought', 'name')
+      @expected_thought.attributes.slice('id', 'thought', 'name', 'mood')
     end
   end
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -48,9 +48,10 @@ RSpec.configure do |config|
             type: 'object',
             properties: {
               thought: { type: 'string', minLength: 1 },
-              name: { type: 'string', minLength: 1 }
+              name: { type: 'string', minLength: 1 },
+              mood: { type: 'string', minLength: 1 }
             },
-            required: %w[thought name]
+            required: %w[thought name mood]
           },
           create_random_thought: {
             type: 'object',
@@ -64,15 +65,17 @@ RSpec.configure do |config|
             properties: {
               id: { type: 'integer' },
               thought: { type: 'string' },
-              name: { type: 'string' }
+              name: { type: 'string' },
+              mood: { type: 'string', minLength: 1 }
             },
-            required: %w[id thought name]
+            required: %w[id thought name mood]
           },
           updated_random_thought: {
             type: 'object',
             properties: {
               thought: { type: 'string', minLength: 1 },
-              name: { type: 'string', minLength: 1 }
+              name: { type: 'string', minLength: 1 },
+              mood: { type: 'string', minLength: 1 }
             }
           },
           update_random_thought: {

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -534,9 +534,13 @@ components:
         name:
           type: string
           minLength: 1
+        mood:
+          type: string
+          minLength: 1
       required:
       - thought
       - name
+      - mood
     create_random_thought:
       type: object
       properties:
@@ -553,10 +557,14 @@ components:
           type: string
         name:
           type: string
+        mood:
+          type: string
+          minLength: 1
       required:
       - id
       - thought
       - name
+      - mood
     updated_random_thought:
       type: object
       properties:
@@ -564,6 +572,9 @@ components:
           type: string
           minLength: 1
         name:
+          type: string
+          minLength: 1
+        mood:
           type: string
           minLength: 1
     update_random_thought:


### PR DESCRIPTION
# What
In preparation for the initial release/vision, this changeset adds a `mood` attribute to the RandomThought.

# Why
For the initial release/vision of the application, the Random Thought `name` will be the user's `display_name` and there is also a `mood` for the thought.  This changeset adds that `mood`.

# Change Impact Analysis and Testing
This change impacts the random thought model, response, index, show, create, and update endpoints.

Changed behavior of the added `mood` attribute to a final thought is verified by...
- [x] Running modified automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

No regressions to existing functionality is verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Updated README was verified by...
- [x] Manual inspection on branch
