### PR TITLE
Change Name Field Value in Random Thought Response to the Random Thought's Creator's Display Name

### DIFF
--- a/app/views/random_thoughts/_random_thought.json.jbuilder
+++ b/app/views/random_thoughts/_random_thought.json.jbuilder
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
-json.call(random_thought, :id, :thought, :name, :mood)
+json.id random_thought.id
+json.thought random_thought.thought
+json.mood random_thought.mood
+json.name random_thought.user.display_name

--- a/spec/requests/get_random_thought_spec.rb
+++ b/spec/requests/get_random_thought_spec.rb
@@ -7,6 +7,7 @@ require_relative '../support/shared_examples/random_thought_response'
 RSpec.describe 'get /random_thoughts/{id}' do
   context 'when {id} exists' do
     let(:random_thought) { create(:random_thought) }
+    let(:user) { random_thought.user }
 
     before do
       get random_thought_path(random_thought)

--- a/spec/requests/get_random_thoughts_spec.rb
+++ b/spec/requests/get_random_thoughts_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'get /random_thoughts/' do
         all_returned = data_body
         RandomThought.page(page).each do |random_thought|
           returned = all_returned.shift
-          expect(returned).to be_random_thought_json(random_thought)
+          expect(returned).to be_random_thought_json(random_thought, random_thought.user)
         end
       end
     end

--- a/spec/requests/update_random_thought_spec.rb
+++ b/spec/requests/update_random_thought_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'patch /random_thoughts/{id}' do
 
       it 'returns updated random_thought JSON' do
         patch_random_thought(random_thought, valid_auth_jwt, update)
-        expect(json_body).to be_random_thought_json(random_thought_update)
+        expect(json_body).to be_random_thought_json(random_thought_update, random_thought.user)
       end
     end
 

--- a/spec/support/matchers/be_random_thought_json.rb
+++ b/spec/support/matchers/be_random_thought_json.rb
@@ -5,15 +5,16 @@
 # JSON response
 module BeRandomThoughtJson
   class BeRandomThoughtJson
-    def initialize(expected_thought)
+    def initialize(expected_thought, user)
       @expected_thought = expected_thought
+      @user = user
     end
 
     def matches?(actual)
       @actual = actual
 
       @actual['thought'] == @expected_thought.thought &&
-        @actual['name'] == @expected_thought.name &&
+        @actual['name'] == @user.display_name &&
         @actual['mood'] == @expected_thought.mood
     end
 
@@ -34,12 +35,14 @@ module BeRandomThoughtJson
     end
 
     def matched_expected
-      @expected_thought.attributes.slice('id', 'thought', 'name', 'mood')
+      expected = @expected_thought.attributes.slice('id', 'thought', 'mood')
+      expected['name'] = @user.display_name
+      expected
     end
   end
 
-  def be_random_thought_json(expected_thought)
-    BeRandomThoughtJson.new(expected_thought)
+  def be_random_thought_json(expected_thought, user)
+    BeRandomThoughtJson.new(expected_thought, user)
   end
 end
 

--- a/spec/support/shared_examples/random_thought_response.rb
+++ b/spec/support/shared_examples/random_thought_response.rb
@@ -2,6 +2,6 @@
 
 RSpec.shared_examples 'random thought response' do
   it 'returns random_thought JSON with correct values' do
-    expect(json_body).to be_random_thought_json(random_thought)
+    expect(json_body).to be_random_thought_json(random_thought, user)
   end
 end


### PR DESCRIPTION
# What
In preparation for the initial release/vision, this changeset changes the value of the `name` field in a Random Thought response to the Random Thought's creator's `display_name`.

# Why
This is in preparation for the initial release/vision where the `name` field in a Random Thought response is the Random Thought's creator's `display_name`.

# Change Impact Analysis and Testing
This change relates to the Random Thought response(s) and related tests.

Changed behavior of the the value of the `name` field in a Random Thought response is the Random Thought's creator's `display_name` is verified by...
- [x] Running modified automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

No regressions to existing functionality is verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI