### PR TITLE
Remove name Column from RandomThoughts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ that implements a random thought in JSON format...
 ```json
 {
   "thought": "A random thought",
-  "name": "The thinker's name",
-  "mood": "The thinker's mood leading to the thought"
+  "mood": "The thinker's mood leading to the thought",
+  "name": "The creating user's display name"
 }
 ```
 
@@ -93,7 +93,6 @@ This API contains the following endpoints...
     {
       "random_thought": {
         "thought": "string",
-        "name": "string",
         "mood": "string"
       }
     }
@@ -107,7 +106,6 @@ This API contains the following endpoints...
     {
       "random_thought": {
         "thought": "string",
-        "name": "string",
         "mood": "string"
       }
     }

--- a/app/controllers/random_thoughts_controller.rb
+++ b/app/controllers/random_thoughts_controller.rb
@@ -42,7 +42,7 @@ class RandomThoughtsController < ApplicationController
   private
 
   def random_thought_params
-    params.required(:random_thought).permit(:thought, :name, :mood)
+    params.required(:random_thought).permit(:thought, :mood)
   end
 
   def find_random_thought

--- a/app/models/random_thought.rb
+++ b/app/models/random_thought.rb
@@ -7,7 +7,6 @@ class RandomThought < ApplicationRecord
   default_scope -> { order(created_at: :desc) }
 
   validates :thought, presence: true
-  validates :name, presence: true
   validates :mood, presence: true
 
 end

--- a/db/migrate/20230316185257_remove_name_from_random_thoughts.rb
+++ b/db/migrate/20230316185257_remove_name_from_random_thoughts.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromRandomThoughts < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :random_thoughts, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_16_154729) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_16_185257) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
 
   create_table "random_thoughts", force: :cascade do |t|
     t.string "thought", null: false
-    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,5 +7,4 @@ first_user = User.create!(email: 'qhound@thisisfine.com', display_name: 'Questio
 User.create!(email: 'user@example.com', display_name: 'Ann User',
              password: 'password', password_confirmation: 'password')
 
-RandomThought.create!(thought: 'This is fine', name: 'Question Hound',
-                      mood: 'Fiery', user: first_user)
+RandomThought.create!(thought: 'This is fine', mood: 'Fiery', user: first_user)

--- a/spec/factories/random_thoughts.rb
+++ b/spec/factories/random_thoughts.rb
@@ -5,15 +5,10 @@ FactoryBot.define do
     association :user
 
     thought { Faker::Lorem.sentence }
-    name { Faker::Name.name }
     mood { Faker::Lorem.sentence }
 
     trait :empty_thought do
       thought { '' }
-    end
-
-    trait :empty_name do
-      name { '' }
     end
 
     trait :empty_mood do
@@ -22,7 +17,6 @@ FactoryBot.define do
 
     trait :empty do
       empty_thought
-      empty_name
       empty_mood
     end
   end

--- a/spec/models/random_thought_spec.rb
+++ b/spec/models/random_thought_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe RandomThought do
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:thought) }
-    it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:mood) }
   end
 end

--- a/spec/requests/swagger_random_thoughts_spec.rb
+++ b/spec/requests/swagger_random_thoughts_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'random_thoughts' do
 
       response(422, 'unprocessable entity') do
         let(:random_thought) { build_random_thought_body(build(:random_thought, :empty)) }
-        msg = "Validation failed: Thought can't be blank, Name can't be blank"
+        msg = "Validation failed: Thought can't be blank, Mood can't be blank"
         it_behaves_like 'unprocessable entity schema', msg
         run_test!
       end
@@ -137,7 +137,7 @@ RSpec.describe 'random_thoughts' do
       end
 
       response(422, 'unprocessable entity') do
-        msg = "Validation failed: Thought can't be blank, Name can't be blank"
+        msg = "Validation failed: Thought can't be blank, Mood can't be blank"
         it_behaves_like 'unprocessable entity schema', msg
         let(:empty_values) { build_random_thought_body(build(:random_thought, :empty)) }
         let(:update) { empty_values }

--- a/spec/requests/update_random_thought_spec.rb
+++ b/spec/requests/update_random_thought_spec.rb
@@ -44,12 +44,6 @@ RSpec.describe 'patch /random_thoughts/{id}' do
         expect(random_thought.reload.thought).to eql(random_thought_update.thought)
       end
 
-      it 'updates name when supplied' do
-        just_name = random_thought_update_just_keys(update, 'name')
-        patch_random_thought(random_thought, valid_auth_jwt, just_name)
-        expect(random_thought.reload.name).to eql(random_thought_update.name)
-      end
-
       it 'updates mood when supplied' do
         just_mood = random_thought_update_just_keys(update, 'mood')
         patch_random_thought(random_thought, valid_auth_jwt, just_mood)

--- a/spec/support/helpers/random_thought_helper.rb
+++ b/spec/support/helpers/random_thought_helper.rb
@@ -2,7 +2,7 @@
 
 module RandomThoughtHelper
   def build_random_thought_body(random_thought)
-    body = random_thought.attributes.slice('thought', 'name', 'mood')
+    body = random_thought.attributes.slice('thought', 'mood')
     { random_thought: body }
   end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -48,10 +48,9 @@ RSpec.configure do |config|
             type: 'object',
             properties: {
               thought: { type: 'string', minLength: 1 },
-              name: { type: 'string', minLength: 1 },
               mood: { type: 'string', minLength: 1 }
             },
-            required: %w[thought name mood]
+            required: %w[thought mood]
           },
           create_random_thought: {
             type: 'object',
@@ -65,8 +64,8 @@ RSpec.configure do |config|
             properties: {
               id: { type: 'integer' },
               thought: { type: 'string' },
-              name: { type: 'string' },
-              mood: { type: 'string', minLength: 1 }
+              mood: { type: 'string', minLength: 1 },
+              name: { type: 'string' }
             },
             required: %w[id thought name mood]
           },
@@ -74,7 +73,6 @@ RSpec.configure do |config|
             type: 'object',
             properties: {
               thought: { type: 'string', minLength: 1 },
-              name: { type: 'string', minLength: 1 },
               mood: { type: 'string', minLength: 1 }
             }
           },

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -132,7 +132,7 @@ paths:
                   value:
                     status: 422
                     error: unprocessable_entity
-                    message: 'Validation failed: Thought can''t be blank, Name can''t
+                    message: 'Validation failed: Thought can''t be blank, Mood can''t
                       be blank'
               schema:
                 "$ref": "#/components/schemas/error"
@@ -232,7 +232,7 @@ paths:
                   value:
                     status: 422
                     error: unprocessable_entity
-                    message: 'Validation failed: Thought can''t be blank, Name can''t
+                    message: 'Validation failed: Thought can''t be blank, Mood can''t
                       be blank'
               schema:
                 "$ref": "#/components/schemas/error"
@@ -531,15 +531,11 @@ components:
         thought:
           type: string
           minLength: 1
-        name:
-          type: string
-          minLength: 1
         mood:
           type: string
           minLength: 1
       required:
       - thought
-      - name
       - mood
     create_random_thought:
       type: object
@@ -555,11 +551,11 @@ components:
           type: integer
         thought:
           type: string
-        name:
-          type: string
         mood:
           type: string
           minLength: 1
+        name:
+          type: string
       required:
       - id
       - thought
@@ -569,9 +565,6 @@ components:
       type: object
       properties:
         thought:
-          type: string
-          minLength: 1
-        name:
           type: string
           minLength: 1
         mood:


### PR DESCRIPTION
# What
This changeset removes the `name` column from the RandomThoughts model/table and updates tests and documentation accordingly.

# Why
Now that the `name` value in the Random Thought response is the creating user's (current) display name, the name field in the RandomThoughts model/table is no longer needed.

# Change Impact Analysis and Testing
This change impacts the RandomThoughts model and creation/update request body.

Removed `name` field in RandomThought response is verified by...
- [x] Inspection of code related to Random Thought
- [x] Running modified automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

No regressions to existing functionality is verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Updated documentation is verified by...
- [x] Manual inspection of README on branch
- [x] Manual inspection of modified endpoints in Swagger UI