### PR TITLE
Improve consistency and Performance by Adding User Display Name Index And Default Scope

### DIFF
--- a/app/models/random_thought.rb
+++ b/app/models/random_thought.rb
@@ -4,7 +4,7 @@
 class RandomThought < ApplicationRecord
   belongs_to :user
 
-  default_scope -> { order(created_at: :desc) }
+  default_scope -> { order(created_at: :desc) }, all_queries: true
 
   validates :thought, presence: true
   validates :mood, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
 
   has_many :random_thoughts, dependent: :destroy
 
+  default_scope -> { order(display_name: :asc) }, all_queries: true
+
   validates :email, presence: true, uniqueness: true,
                     # NOTE: citext (db) does not support max length constraint
                     length: {

--- a/db/migrate/20230317163241_add_display_name_index_to_users.rb
+++ b/db/migrate/20230317163241_add_display_name_index_to_users.rb
@@ -1,0 +1,5 @@
+class AddDisplayNameIndexToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_index :users, :display_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_16_185257) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_17_163241) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -32,6 +32,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_16_185257) do
     t.datetime "updated_at", null: false
     t.string "password_digest"
     t.bigint "authorization_min", default: -9223372036854775808
+    t.index ["display_name"], name: "index_users_on_display_name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.check_constraint "length(email::text) < 255", name: "email_length_check"
   end

--- a/spec/models/random_thought_spec.rb
+++ b/spec/models/random_thought_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RandomThought do
   end
 
   describe 'default scope' do
-    it 'returns most recent first' do
+    it 'orders by most recent first' do
       create_list(:random_thought, 20)
       most_recent = create(:random_thought)
       expect(described_class.first).to eql(most_recent)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe User do
     it { is_expected.to have_many(:random_thoughts).dependent(:destroy) }
   end
 
+  describe 'default scope' do
+    it 'orders by ascending display name' do
+      first_user = create(:user, display_name: 'aa')
+      second_user = create(:user, display_name: 'a')
+      expect(described_class.all).to eq([second_user, first_user])
+    end
+  end
+
   describe 'validations' do
     describe 'email' do
       let(:valid_but_rejected_email) { '"Some spaces! And @ sign too!" @some.server.com' }


### PR DESCRIPTION
# What
This changeset adds an index for the User `display_name` and sets the default scope for User to be ordered by the `display_name` in ascending order.  This makes the paginated `get /users` `index` route ordering consistent.

# Why
Adding the default scope makes the  paginated `get /users` `index` route ordering consistent and adding the index on `display_name` makes this ordering more performant.  This index will be used in the future to provide performant ability to get all Random Thoughts for a given user by that user's Display Name.


# Change Impact Analysis and Testing
This change is restricted to the User model and its default scope which is visible to the user through the returned order in the `get /users` endpoint.

Changed behavior of the default scope for User is verified by...
- [x] Running added scope User Model automated test (CI)
- [x] Manual exploratory testing using Swagger UI to ensure order is correct and consistent for different users for the `get /users` endpoint

No regressions to existing functionality is verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI
