### PR TITLE
Enhance Operationality and Resiliency by Adding Health Check Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,18 @@ This API contains the following endpoints...
     > **Requires** Authorization JWT from login
     > in request header
 
+## Health Checks
+There are two health-check endpoints for determining the current
+health status of the application:
+
+* `/livez` - a *Liveness* endpoint that indicates that the
+  application is running but not necessarily healthy
+  (e.g. http://localhost:3000/livez)
+
+* `/readyz` - a *Readiness* endpoint that indicates that the
+  application is healthy and ready for requests
+  (e.g. http://localhost:3000/readyz)
+
 ## Development
 This project can be developed using the supplied basic,
 container-based development environment which includes

--- a/config.ru
+++ b/config.ru
@@ -4,3 +4,16 @@ require_relative "config/environment"
 
 run Rails.application
 Rails.application.load_server
+
+# --- CUSTOM ---
+# Add health checks
+require_relative 'lib/rack/live_check'
+require_relative 'lib/rack/ready_check'
+
+map '/livez' do
+  run Rack::LiveCheck.new
+end
+
+map '/readyz' do
+  run Rack::ReadyCheck.new
+end

--- a/lib/rack/live_check.rb
+++ b/lib/rack/live_check.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Rack
+  # Most basic health check that simply indicates that the application is up
+  # but not necessarily ready for traffic
+  class LiveCheck
+    def call(_env)
+      # Must be alive to reach this
+      [
+        200,
+        { 'Content-type' => 'application/json; charset=utf-8' },
+        ['{ "status": 200, "message": "alive" }']
+      ]
+    end
+  end
+end

--- a/lib/rack/ready_check.rb
+++ b/lib/rack/ready_check.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Rack
+  # Health check to ensure the database is ready for traffic
+  class ReadyCheck
+    def initialize
+      @body_details = {}
+    end
+
+    def call(_env)
+      response = ready? ? ready_response : error_response
+      response.finish
+    end
+
+    def ready?
+      database_connected?
+    end
+
+    def database_connected?
+      ActiveRecord::Base.connection.execute('SELECT 1')
+      @body_details[:database_connection] = 'ok'
+    rescue StandardError
+      @body_details[:database_connection] = 'error'
+      false
+    end
+
+    def ready_response
+      status = 200
+      response_body = { status:, message: 'ready' }.merge(@body_details)
+      rack_response(response_body, status)
+    end
+
+    def error_response
+      status = 503
+      response_body = { status:, message: 'error' }.merge(@body_details)
+      rack_response(response_body, status)
+    end
+
+    def rack_response(body, status)
+      Rack::Response.new(
+        body.to_json,
+        status,
+        response_header
+      )
+    end
+
+    def response_header
+      { 'Content-type' => 'application/json; charset=utf-8' }
+    end
+  end
+end


### PR DESCRIPTION
# What
This changeset adds two health-check endpoints (`/livez` and `/readyz`) to the Rack middleware.

# Why
Liveness and Readiness health-checks make this application more operational and resilient by providing an external means to determine the status and health of the application.  These Liveness and Readiness health-checks are used by orchestration and monitoring systems to ensure that the application is available and alert if not. 

# Change Impact Analysis and Testing
New health-check endpoints functionality are verified by...
- [x] Manual testing

No regressions to existing functionality is verified by...
- [x] Running existing automated tests (CI)

Updated README was verified by...
- [x] Manual inspection on branch