### PR TITLE
Fix issue of dockercomposerun Leaving App Container 

### DIFF
--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -56,10 +56,10 @@ echo ''
 echo "DOCKER-COMPOSE RUNNING [$@]..."
 # Allow to fail but catch return code
 set +e
-# Specify the --service-ports option to expose app's PORTS 
+# Specify the --service-ports option to expose app's PORTS
 # on host machine (by default docker-compose run does not
 # expose host ports)
-$docker_compose_command run --service-ports app "$@"
+$docker_compose_command run --rm --service-ports app "$@"
 run_return_code=$?
 # NOTE return code must be caught before any other command
 set -e


### PR DESCRIPTION
# What
This infrastructure-only changeset fixes the issue of not removing the stopped app image when using the docker compose framework.

# Why
Leaving the stopped app container was bad practice and caused issues unders certain circumstances when that container name was reused.

# Change Impact Analysis and Testing

- [x] Proper running and removal of containers in docker compose framework verified with manual testing
- [x] No regressions to existing functionality is verified by CI checks
