### PR TITLE
Follow REST Standards by Making Logout Be delete /login

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ This API contains the following endpoints...
     }
     ```
 
-  * **Logout** user: `get /logout`
-    (e.g. http://localhost:3000/logout)
+  * **Logout** user: `delete /login`
     > **Requires** Authorization JWT from login
     > in request header
 

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 # Implements application authentication actions
+# NOTE: the restful actions of create (POST) login
+# and DELETE login are mapped to the more intuitive
+# actions of login and logout
 class AuthenticationController < ApplicationController
   include Authorization::JsonWebToken
 
   before_action :authorize_request, only: %i[logout]
 
-  # Post /authentication/login
+  # POST /authentication/login
   def login
     @user = User.find_by(email: params[:authentication][:email])
     if @user&.authenticate(params[:authentication][:password])
@@ -18,6 +21,7 @@ class AuthenticationController < ApplicationController
     end
   end
 
+  # DELETE /authentication/login
   def logout
     @current_user.revoke_auth
     logger.info "Logout: Logged out user [#{@current_user.email}]"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   post '/login', to: 'authentication#login', defaults: { format: 'json' }
-  get  '/logout', to: 'authentication#logout', defaults: { format: 'json' }
+  delete '/login', to: 'authentication#logout', as: 'logout', defaults: { format: 'json' }
 
   resources :random_thoughts, defaults: { format: 'json' }
   resources :users, defaults: { format: 'json' }, only: %i[index show create update destroy]

--- a/spec/requests/auth/logout_spec.rb
+++ b/spec/requests/auth/logout_spec.rb
@@ -5,14 +5,14 @@ require 'rails_helper'
 require_relative '../../support/helpers/jwt_helper'
 require_relative '../../support/shared_examples/jwt_authorization'
 
-RSpec.describe 'get /logout' do
+RSpec.describe 'delete /login' do
   include JwtHelper
 
   let(:user) { create(:user) }
 
   describe 'authorization' do
-    let(:request_without_jwt) { get logout_path }
-    let(:request_with_jwt) { get_logout(jwt) }
+    let(:request_without_jwt) { delete logout_path }
+    let(:request_with_jwt) { logout(jwt) }
 
     it_behaves_like 'jwt_authorization'
   end
@@ -21,13 +21,13 @@ RSpec.describe 'get /logout' do
     let(:valid_auth_jwt) { valid_jwt(user) }
 
     before do |example|
-      get_logout(valid_auth_jwt) unless example.metadata[:skip_before]
+      logout(valid_auth_jwt) unless example.metadata[:skip_before]
     end
 
     # TODO: Should this be user.id instead of email?
     it 'logs that the user has been logged out', :skip_before do
       allow(Rails.logger).to receive(:info)
-      get_logout(valid_auth_jwt)
+      logout(valid_auth_jwt)
       expect(Rails.logger).to have_received(:info).with("Logout: Logged out user [#{user.email}]")
     end
 
@@ -42,7 +42,7 @@ RSpec.describe 'get /logout' do
 
   private
 
-  def get_logout(jwt)
-    get logout_path, headers: authorization_header(jwt)
+  def logout(jwt)
+    delete logout_path, headers: authorization_header(jwt)
   end
 end

--- a/spec/requests/auth/swagger_authentication_spec.rb
+++ b/spec/requests/auth/swagger_authentication_spec.rb
@@ -7,12 +7,12 @@ require_relative '../../support/helpers/login_helper'
 require_relative '../../support/shared_examples/errors/bad_request_schema'
 require_relative '../../support/shared_examples/errors/unauthorized_schema'
 
-RSpec.describe 'authentications' do
+RSpec.describe 'authentication' do
   include JwtHelper
   include LoginHelper
 
   path '/login' do
-    post('login') do
+    post('login user') do
       consumes 'application/json'
       produces 'application/json'
       parameter name: :login,
@@ -36,10 +36,8 @@ RSpec.describe 'authentications' do
         run_test!
       end
     end
-  end
 
-  path '/logout' do
-    get('logout') do
+    delete('logout user') do
       consumes 'application/json'
       produces 'application/json'
       security [bearer: []]

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -6,7 +6,7 @@ info:
 paths:
   "/login":
     post:
-      summary: login
+      summary: login user
       parameters: []
       responses:
         '200':
@@ -37,9 +37,8 @@ paths:
           application/json:
             schema:
               "$ref": "#/components/schemas/login"
-  "/logout":
-    get:
-      summary: logout
+    delete:
+      summary: logout user
       security:
       - bearer: []
       responses:


### PR DESCRIPTION
# What
This changeset changes the routing of Logout from `get /logout` to `delete /login`. 

# Why
This change makes this application follow RESTful standards and practices by changing the logout action from `get /logout` to `delete /login` with the allowance that "login" is a noun.

# Change Impact Analysis and Testing
This change only impacts the logout action routing and tests.

Changed routing behavior verified by...
- [x] Running updated automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

No regressions to existing functionality is verified by...
- [x] Running existing automated tests (CI)
- [x] Manual exploratory testing using Swagger UI

Updated documentation verified by...
- [x] Manual inspection of README on branch
- [x] Manual inspection of Swagger UI