### PR TITLE
Improve Security Auditability by Logging Both the User's ID and Email for Login and Logout

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Implements application authentication actions
-# NOTE: the restful actions of create (POST) login
+# NOTE: The RESTful actions of create (POST) login
 # and DELETE login are mapped to the more intuitive
 # actions of login and logout
 class AuthenticationController < ApplicationController
@@ -14,7 +14,7 @@ class AuthenticationController < ApplicationController
     @user = User.find_by(email: params[:authentication][:email])
     if @user&.authenticate(params[:authentication][:password])
       token = authentication_jwt(app_payload(@user))
-      logger.info "Login: Authenticated user [#{@user.email}]"
+      logger.info "Login: Authenticated user [#{@user.id} (#{@user.email})]"
       render_logged_in(token)
     else
       render_error_status_and_json(:unauthorized, 'Invalid login')
@@ -24,7 +24,7 @@ class AuthenticationController < ApplicationController
   # DELETE /authentication/login
   def logout
     @current_user.revoke_auth
-    logger.info "Logout: Logged out user [#{@current_user.email}]"
+    logger.info "Logout: Logged out user [#{@current_user.id} (#{@current_user.email})]"
     render status: :ok, json: { message: 'User logged out successfully' }
   end
 

--- a/spec/requests/auth/login_spec.rb
+++ b/spec/requests/auth/login_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe 'post /login' do
     it 'logs that the user has been authenticated', :skip_before do
       allow(Rails.logger).to receive(:info)
       post_login(valid_user)
-      expect(Rails.logger).to have_received(:info).with("Login: Authenticated user [#{valid_user.email}]")
+      log_user_id_and_email = "Login: Authenticated user [#{valid_user.id} (#{valid_user.email})]"
+      expect(Rails.logger).to have_received(:info).with(log_user_id_and_email)
     end
 
     it 'returns HS256-encoded JWT in "token"' do

--- a/spec/requests/auth/logout_spec.rb
+++ b/spec/requests/auth/logout_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe 'delete /login' do
       logout(valid_auth_jwt) unless example.metadata[:skip_before]
     end
 
-    # TODO: Should this be user.id instead of email?
     it 'logs that the user has been logged out', :skip_before do
       allow(Rails.logger).to receive(:info)
       logout(valid_auth_jwt)
-      expect(Rails.logger).to have_received(:info).with("Logout: Logged out user [#{user.email}]")
+      log_user_id_and_email = "Logout: Logged out user [#{user.id} (#{user.email})]"
+      expect(Rails.logger).to have_received(:info).with(log_user_id_and_email)
     end
 
     it 'revokes users authorization' do


### PR DESCRIPTION
# What
This changeset simply changes the logging during login and logout to also include the user's ID in addition to the user's email.

# Why
Logging the User's ID (which should be immutable) in addition to the current User's email (which can be changed) should increase auditability. 

# Change Impact Analysis and Testing
This change only impacts logging during login and logout.

Changed logging behavior verified by...
- [x] Running updated automated tests (CI)
