### PR TITLE
Add Self-Documenting/Describing Root Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ This API contains the following endpoints...
     > **Requires** Authorization JWT from login
     > in request header
 
+## Self-Documenting Root Endpoint
+The root endpoint (i.e. `get /`) returns the application's
+Swagger File (i.e. OpenAPI specification) in JSON, thus making
+this application self-documenting.
+
 ## Health Checks
 There are two health-check endpoints for determining the current
 health status of the application:

--- a/app/controllers/documentation_controller.rb
+++ b/app/controllers/documentation_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# This application's documentation as a read-only resource
+class DocumentationController < ApplicationController
+  def show
+    swagger_file = JSON.pretty_generate(YAML.load_file(File.open('swagger/v1/swagger.yaml')))
+    render status: :ok, json: swagger_file
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  root to: 'documentation#show'
+
   post '/login', to: 'authentication#login', defaults: { format: 'json' }
   delete '/login', to: 'authentication#logout', as: 'logout', defaults: { format: 'json' }
 

--- a/spec/requests/root_spec.rb
+++ b/spec/requests/root_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Root' do
+  describe 'GET /' do
+    before do
+      get root_path
+    end
+
+    it 'returns 200' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns Swagger File in Pretty JSON' do
+      swagger_file_json = JSON.pretty_generate(YAML.load_file(File.open('swagger/v1/swagger.yaml')))
+      expect(response.body).to eq(swagger_file_json)
+    end
+  end
+end


### PR DESCRIPTION
# What
This changeset adds a self-describing/self-documenting root endpoint (i.e. `get /`) by creating a new `documentation` controller with a `show` action that returns the application's Swagger File in Pretty JSON and setting `root` to this action in the routing.  

# Why
Making the application self-describing follows the tenets of [Hypermedia as the Engine of Application State (HATEOAS)](https://en.wikipedia.org/wiki/HATEOAS) which is a key constraint of a RESTful architecture.

# Change Impact Analysis and Testing
This change is limited to the new `documentation` controller and the application's routing.

New root endpoint behavior is verified by...
- [x] Running added automated tests (CI)

No regressions to existing functionality is verified by...
- [x] Running existing automated tests (CI)

Updated README was verified by...
- [x] Manual inspection on branch
