### PR TITLE
Slightly Simplify Swagger Specification by Removing oneOf from get user

### DIFF
--- a/spec/requests/v1/users/swagger_users_spec.rb
+++ b/spec/requests/v1/users/swagger_users_spec.rb
@@ -104,8 +104,7 @@ RSpec.describe 'v1/users', swagger_doc: 'v1/swagger.yaml' do
         # NOTE: This is intended to test different users
         let(:id) { create(:user).id }
 
-        schema oneOf: [{ '$ref' => '#/components/schemas/same_user_response' },
-                       { '$ref' => '#/components/schemas/different_user_response' }]
+        schema '$ref' => '#/components/schemas/user_response'
         run_test!
       end
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -132,13 +132,6 @@ RSpec.configure do |config|
             },
             required: %w[id email display_name]
           },
-          different_user_response: {
-            type: 'object',
-            properties: {
-              display_name: { type: 'string', minLength: 1 }
-            },
-            required: %w[display_name]
-          },
           updated_user: {
             type: 'object',
             properties: {

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -382,9 +382,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                - "$ref": "#/components/schemas/same_user_response"
-                - "$ref": "#/components/schemas/different_user_response"
+                "$ref": "#/components/schemas/user_response"
         '401':
           description: unauthorized
           content:
@@ -649,14 +647,6 @@ components:
       required:
       - id
       - email
-      - display_name
-    different_user_response:
-      type: object
-      properties:
-        display_name:
-          type: string
-          minLength: 1
-      required:
       - display_name
     updated_user:
       type: object


### PR DESCRIPTION
# What
This changeset slightly simplifies the Swagger/OpenAPI specification by removing the `oneOf` definition from `get /v1/users/{id}` and instead using the more generic `user_response` schema.  This changeset also removes the now unused `different_user_response` schema.  This does not change the actual response just specification although the specification is logically the same.

# Why
The use of `oneOf` only added addition complexity and an additional `different_user_response` schema.  This may actually help in Swagger server/client code generation.

# Change Impact Analysis and Testing
Removed `oneOf` and `different_user_response` verified by...
- [x] Manual inspection of generated Swagger.yml
- [x] Manual inspection of Swagger UI

Verified that correct user response with correct fields are covered by automated tests by...
- [x] "Breaking" view logic that sends different response to  `get /v1/users/{id}` and ensuring that test fails

No regressions to existing functionality verified by...
- [x] Running automated tests (CI)
