### PR TITLE
Path to Production Preparation: Enable CORS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "bootsnap", require: false
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem "rack-cors"
+gem "rack-cors"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.2)
     rack (2.2.6.4)
+    rack-cors (2.0.1)
+      rack (>= 2.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.4.3)
@@ -254,6 +256,7 @@ DEPENDENCIES
   kaminari
   pg (~> 1.1)
   puma (~> 5.0)
+  rack-cors
   rails (~> 7.0.4)
   rspec-rails
   rswag-api

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,35 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  open_public_access = '*'
+
+  # FOR NOW allow open public access to healthchecks but these
+  # should probably be restricted to localhost, same network zone.
+  # and our health monitoring services
+  allow do
+    origins open_public_access
+
+    resource '/livez, /readyz',
+             headers: :any,
+             methods: [:get]
+  end
+
+  # For the API-documenting root route, allow open public access
+  allow do
+    origins open_public_access
+
+    resource '/',
+             headers: :any,
+             methods: [:get]
+  end
+
+  # For the API endpoints themselves (including root), allow open public access
+  allow do
+    origins open_public_access
+
+    resource '/v1/*',
+             headers: :any,
+             methods: %i[get post patch delete]
+  end
+end


### PR DESCRIPTION
# What
This changeset enables Cross Origin Resource Sharing (CORS) with full open public access to all domains as this is intended as a public API.  However, the health check routes are separated out in preparation of later restrictions to localhost,same network zone, or specific health/uptime monitoring services.

# Why
This is in preparation of production deployment and allows access to the deployed API.

# Change Impact Analysis and Testing
No regressions to existing functionality verified by...
- [x] Running automated unit and E2E tests (CI)
- [x] Manual exploratory testing with Swagger UI