### PR TITLE
Increase Visibility of Test Coverage by Adding Test Coverage Reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 
 # DO NOT COMMIT .env FILES
 .env
+
+# Ignore coverage reports
+coverage

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+SimpleCov.start 'rails' do
+  enable_coverage :branch
+end

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :development, :test do
   gem 'rubocop', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
+  gem 'simplecov', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     date (3.3.3)
     debug (1.7.1)
     diff-lcs (1.5.0)
+    docile (1.4.0)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -231,6 +232,12 @@ GEM
     ruby-progressbar (1.13.0)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     thor (1.2.1)
     timeout (0.3.2)
     tzinfo (2.0.6)
@@ -266,6 +273,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   shoulda-matchers
+  simplecov
   tzinfo-data
 
 RUBY VERSION

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ container-based development environment which includes
 * [Faker](https://github.com/faker-ruby/faker) - Fuzzing Test Data
 * [Shoulda Matchers](https://matchers.shoulda.io/) - Test Expectation
   Matchers
+* [SimpleCov](https://github.com/simplecov-ruby/simplecov) - Test Coverage
+  Reporting
 * [bundler-audit](https://github.com/rubysec/bundler-audit) - Dependency
   Static Security
 * [rubocop](https://github.com/rubocop/rubocop),

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,7 @@
+# --- CUSTOM REQUIRES ---
+# Require simplecov before other requires
+require 'simplecov'
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
# What
This changeset adds and configures the [SimpleCov](https://github.com/simplecov-ruby/simplecov) gem to generate test coverage reports.

Note that lack of coverage is only for either unused Rails boilerplate code paths or the health checks which are covered by the End-To-End (E2E) tests.

# Why
Adding test coverage reporting will give visibility into code coverage and the risk associated with uncovered code branches.

# Change Impact Analysis and Testing
This only impacts running the unit tests.

- [x] Added coverage report verified by running tests manually and manually inspecting the report
- [x] Verified that coverage report is ignored by source code control
