### PR TITLE
Increase Application Security and Reduce Risk by Adding Brakeman

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -62,6 +62,16 @@ jobs:
       - name: dockercomposerun dependency scanning on development environment
         run: "APP_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -d ./script/run depsecscan"
 
+  vet-static-security:
+    needs: [pr-norm-branch, build-and-push-branch-devenv]
+    runs-on: ubuntu-latest
+    env:
+      DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: dockercomposerun static security analysis on development environment
+        run: "APP_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -d ./script/run statsecscan"
+
   vet-unit-tests:
     needs: [pr-norm-branch, build-and-push-branch-devenv]
     runs-on: ubuntu-latest
@@ -109,6 +119,7 @@ jobs:
       - vet-deploy-as-e2e-tests-target
       - vet-unit-tests
       - vet-swagger-file-currency
+      - vet-static-security
       - vet-dependency-security
       - vet-code-standards
       - build-and-push-branch-unvetted

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'rswag-api'
 gem 'rswag-ui'
 
 group :development, :test do
+  gem 'brakeman'
   gem 'bundler-audit'
   gem 'factory_bot_rails'
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ GEM
     bcrypt (3.1.18)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
+    brakeman (5.4.1)
     builder (3.2.4)
     bundler-audit (0.9.1)
       bundler (>= 1.2.0, < 3)
@@ -264,6 +265,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap
+  brakeman
   bundler-audit
   debug
   factory_bot_rails

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ that contains and demonstrates...
   [GitHub Actions](https://github.com/features/actions)
 * Secrets management
 * Environment variable based configuration
-* Code Style enforcement, linting, and static dependency
-  security scanning
+* Code Style enforcement, linting, and static security
+  analysis and dependency scanning
 
 ## What It Does
 This API represents *Users* and their *RandomThoughts* which
@@ -161,6 +161,7 @@ container-based development environment which includes
   Matchers
 * [SimpleCov](https://github.com/simplecov-ruby/simplecov) - Test Coverage
   Reporting
+* [brakeman](https://brakemanscanner.org/) - Static Security Analysis
 * [bundler-audit](https://github.com/rubysec/bundler-audit) - Dependency
   Static Security
 * [rubocop](https://github.com/rubocop/rubocop),

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,48 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Missing Encryption",
+      "warning_code": 109,
+      "fingerprint": "6a26086cd2400fbbfb831b2f8d7291e320bcc2b36984d2abc359e41b3b63212b",
+      "check_name": "ForceSSL",
+      "message": "The application does not force use of HTTPS: `config.force_ssl` is not enabled",
+      "file": "config/environments/production.rb",
+      "line": 1,
+      "link": "https://brakemanscanner.org/docs/warning_types/missing_encryption/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "High",
+      "cwe_id": [
+        311
+      ],
+      "note": "Currently HTTPS not required"
+    },
+    {
+      "warning_type": "Unscoped Find",
+      "warning_code": 82,
+      "fingerprint": "bdbc61c0ca28dc7d8f85d53cb804fb823e3a1032283c4c2ccab0447994c97645",
+      "check_name": "UnscopedFind",
+      "message": "Unscoped call to `RandomThought#find`",
+      "file": "app/controllers/v1/random_thoughts_controller.rb",
+      "line": 52,
+      "link": "https://brakemanscanner.org/docs/warning_types/unscoped_find/",
+      "code": "RandomThought.find(params[:id])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "V1::RandomThoughtsController",
+        "method": "find_random_thought"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "cwe_id": [
+        285
+      ],
+      "note": "Authorization not required to view Random Thoughts"
+    }
+  ],
+  "updated": "2023-04-20 19:29:35 +0000",
+  "brakeman_version": "5.4.1"
+}

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -77,6 +77,17 @@ Run the following command to run the dependency security scan...
 ./script/run depsecscan
 ```
 
+### Static Security Analysis
+This project includes the
+[`brakeman`](https://brakemanscanner.org/)
+gem for statically analyzing the project for any security
+vulnerabilities.
+
+Run the following command to run the static security analysis...
+```
+./script/run statsecscan
+```
+
 ### Running the Server
 Run the following command to run the Rails server...
 ```

--- a/script/run
+++ b/script/run
@@ -5,7 +5,8 @@
 #   - rails
 #   - tests
 #   - lint
-#   - depecscan
+#   - depsecscan
+#   - statsecscan
 #   - swaggerize
 #   - or it runs all arguments
 # -----------------------------------------------
@@ -69,6 +70,11 @@ case "$action" in
   "depsecscan")
     shift
     run_command="bundle exec bundle-audit check --update $@"
+  ;;
+
+    "statsecscan")
+    shift
+    run_command="bundle exec brakeman --run-all-checks --color -o /dev/stdout $@"
   ;;
 
   "swaggerize")


### PR DESCRIPTION
# What
This pull request adds the [brakeman](https://brakemanscanner.org/) gem to the project, adding support in the `run` script as well as running `brakeman` as part of the CI checks.  Brakeman is a static security analysis tool.

# Why
Adding this static security analysis especially as part of the Continuous Integration checks should increase the application security and reduce risk.

# Change Impact Analysis and Testing
Running the added brakeman using the `run` script vetted by...
- [x] Successful run of CI checks
- [x] Manual inspection of added vetting in CI checks

Updated documentation vetted by...
- [x]  Manual inspection on branch
