### PR TITLE
Increase Reliability By Adding Perf Tests To Docker Compose Environment

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,12 +1,6 @@
 version: '3.8'
 services:
   app:
-    healthcheck:
-      test: ["CMD", "bash", "-c", "ruby", "app_isready.rb"]
-      start_period: 10s
-      interval: 10s
-      timeout: 5s
-      retries: 10
     command: ./entrypoint.sh
 
   e2etests:

--- a/docker-compose.perf.yml
+++ b/docker-compose.perf.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+services:
+  app:
+    command: ./entrypoint.sh
+
+  perftests:
+    image: "${PERFTESTS_IMAGE:-grafana/k6:latest}"
+    container_name: ${PERFTESTS_HOSTNAME:-perftests}
+    environment:
+      - PERF_BASE_URL=http://${APP_HOSTNAME:-app}:${PORT:-3000}
+    volumes:
+      # Mount the k6 script to run
+      - ${PERFTESTS_SCRIPT:-./k6/script.js}:/script.js
+    command: run /script.js
+    depends_on:
+      app:
+        condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,3 +22,9 @@ services:
       - ${PORT:-3000}:${PORT:-3000}
     expose:
       - ${PORT:-3000}
+    healthcheck:
+      test: ["CMD", "bash", "-c", "ruby", "app_isready.rb"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 10

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -109,6 +109,20 @@ following command...
 APP_IMAGE=rta ./script/dockercomposerun -ct
 ```
 
+### Running the Perf Tests
+You can also run the Perf(ormance) tests using the `dockercomposerun`
+script with the `-p` (Perf tests) option.  This will pull the
+[grafana/k6](https://k6.io/) load test tool image and run the
+specified test script against the running application container.
+
+To specify the tests script, use the `PERFTESTS_SCRIPT` environment
+variable (e.g. `PERFTESTS_SCRIPT=./k6/user_create_stress_test.js`)
+
+To run the load test for creating a user, run the following command...
+```
+PERFTESTS_SCRIPT=./k6/user_create_stress_test.js ./script/dockercomposerun -p
+```
+
 ### Operating
 :eyes: For information on operating the application including
 running the unit tests, static dependency security scanning,

--- a/k6/random_thoughts_index_stress_test.js
+++ b/k6/random_thoughts_index_stress_test.js
@@ -1,0 +1,24 @@
+import { check } from 'k6';
+import http from 'k6/http';
+
+export const options = {
+  stages: [
+    { duration: '1m', target: 100 },
+    { duration: '1m', target: 200 },
+    { duration: '1m', target: 400 },
+    { duration: '1m', target: 800 },
+    { duration: '1m', target: 900 },
+    { duration: '1m', target: 1000 },
+    { duration: '1m', target: 1050 },
+    // Timeouts start between 1050 - 1065
+    // { duration: '1m', target: 1065 },
+    { duration: '1m', target: 0 },
+  ],
+};
+
+export default function () {
+  const res = http.get(`${__ENV.PERF_BASE_URL}/v1/random_thoughts/`);
+  check(res, {
+    'is status 200': (r) => r.status === 200,
+  });
+}

--- a/k6/user_create_stress_test.js
+++ b/k6/user_create_stress_test.js
@@ -1,0 +1,37 @@
+import { check } from 'k6';
+import http from 'k6/http';
+import { uuidv4 } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+
+export const options = {
+  stages: [
+    { duration: '1m', target: 100 },
+    { duration: '30s', target: 150 },
+    // Timeouts start around 170ish VUs
+    // { duration: '30s', target: 175 },
+    { duration: '1m', target: 0 },
+  ],
+};
+
+export default function () {
+  const create_user_url = `${__ENV.PERF_BASE_URL}/v1/users/`;
+  const payload = JSON.stringify({
+    user: {
+      email: `${uuidv4()}@test.org`,
+      display_name: `perf test`,
+      password: '12345678',
+      password_confirmation: '12345678',
+    }
+  });
+
+  const params = {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  };
+
+  const res = http.post(create_user_url, payload, params);
+
+  check(res, {
+    'is status 201': (r) => r.status === 201,
+  });
+}

--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -13,11 +13,12 @@
 # -c: Use the docker-compose CI environment with APP_IMAGE
 # -d: Use the docker-compose Dev environment with APP_IMAGE
 # -n: No application database in the docker-compose environment
+# -p: Run the performance tests (and not the app service)
 # -t: Run the e2e tests (and not the app service)
 # ----------------------------------------------------------------------
 
 usage() {
-  echo "Usage: $0 [-cdnt] [CMD]"
+  echo "Usage: $0 [-cdnpt] [CMD]"
 }
 
 err_exit() {
@@ -32,7 +33,7 @@ err_exit() {
 set -e
 
 # Handle options
-while getopts ":cdnt" options; do
+while getopts ":cdnpt" options; do
   case "${options}" in
     c)
       echo "CI Environment"
@@ -49,6 +50,11 @@ while getopts ":cdnt" options; do
       no_database=true
       ;;
 
+    p)
+      echo "Running Perf Tests"
+      run_perftests=true
+      ;;
+
     t)
       echo "Running End-To-End (E2E) Tests"
       run_e2etests=true
@@ -60,6 +66,12 @@ while getopts ":cdnt" options; do
   esac
 done
 shift $((OPTIND-1))
+
+if [ ! -z ${run_perftests} ] && [ ! -z ${run_e2etests} ]; then
+echo ''
+echo "ERROR: you can not select both the '-p' (Perf Tests) and '-t' (End-To-End Tests) options!!!"
+exit 86
+fi
 
 echo ''
 echo "ENVIRONMENT VARIABLES..."
@@ -89,6 +101,11 @@ if [ ! -z ${devenv} ]; then
   docker_compose_command="${docker_compose_command} -f docker-compose.dev.yml "
 fi
 
+if [ ! -z ${run_perftests} ]; then
+  echo "...Running Perf Tests Image [${PERFTESTS_IMAGE}] against Image [${APP_IMAGE}]"
+  docker_compose_command="${docker_compose_command} -f docker-compose.perf.yml "
+fi
+
 if [ ! -z ${run_e2etests} ]; then
   echo "...Running E2E Tests Image [${E2ETESTS_IMAGE}] against Image [${APP_IMAGE}]"
   docker_compose_command="${docker_compose_command} -f docker-compose.e2e.yml "
@@ -116,16 +133,21 @@ echo ''
 echo "DOCKER-COMPOSE RUNNING [$@]..."
 # Allow to fail but catch return code
 set +e
-if [ -z ${run_e2etests} ]; then
+if [ ! -z ${run_perftests} ]; then
+  echo "RUNNING THE PERF TESTS (perftests SERVICE) (NOT app SERVICE)..."
+  $docker_compose_command run --rm perftests "$@"
+  # NOTE return code must be caught before any other command
+  run_return_code=$?
+elif [ ! -z ${run_e2etests} ]; then
+  echo "RUNNING THE E2E TESTS (e2etests SERVICE) (NOT app SERVICE)..."
+  $docker_compose_command run --rm e2etests "$@"
+  # NOTE return code must be caught before any other command
+  run_return_code=$?
+else
   # Specify the --service-ports option to expose app's PORTS
   # on host machine (by default docker-compose run does not
   # expose host ports)
   $docker_compose_command run --rm --service-ports app "$@"
-  # NOTE return code must be caught before any other command
-  run_return_code=$?
-else
-  echo "RUNNING THE E2E TESTS (e2etests SERVICE) (NOT app SERVICE)..."
-  $docker_compose_command run --rm e2etests "$@"
   # NOTE return code must be caught before any other command
   run_return_code=$?
 fi


### PR DESCRIPTION
# What
This changeset adds perf testing to the docker compose environment using [Grafana k6](https://k6.io/) load testing tool.

# Why
Being able to performance test will add reliability to the application.

# Change Impact Analysis and Testing
Verified no regressions in existing capabilities and functionality by...
- [x] Successful execution of CI checks

Verified new ability to run perf tests by...
- [x] Manual testing including setting both `-p` and `-t` options in `dockercomposerun`

Verified updated documentation...
- [x] Manual inspection on branch