### PR TITLE
Add Multi-Architecture Image Support (linux/arm64)

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -9,7 +9,7 @@ on:
 #  Raw Branch Name: ${{ github.head_ref }}
 #  <commit-sha>: ${{ github.event.pull_request.head.sha }}
 
-# Produced images...
+# Produced multi-architecture (linux/amd64,linux/arm64) images...
 #  1. (Always) Unvetted Image: <owner/repository>_<normalized-branch>_unvetted:<commit-sha>
 #  2. (Always) Dev Environment Image: <owner/repository>_<normalized-branch>_dev:<commit-sha>
 #  3. (If vetted) Vetted_image: <owner/repository>_<normalized-branch>:<commit-sha>
@@ -22,28 +22,30 @@ jobs:
       raw_name: ${{ github.head_ref }}
 
   # Build and Push Images
-  build-and-push-branch-devenv:
+  buildx-and-push-branch-devenv:
     needs: [pr-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/build_push_image.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@main
     with:
       image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
+      platforms: "linux/amd64,linux/arm64"
       buildopts: --target devenv
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-  build-and-push-branch-unvetted:
+  buildx-and-push-branch-unvetted:
     needs: [pr-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/build_push_image.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@main
     with:
       image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
+      platforms: "linux/amd64,linux/arm64"
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   # Vetting
   vet-code-standards:
-    needs: [pr-norm-branch, build-and-push-branch-devenv]
+    needs: [pr-norm-branch, buildx-and-push-branch-devenv]
     runs-on: ubuntu-latest
     env:
       DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
@@ -53,7 +55,7 @@ jobs:
         run: "APP_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -d ./script/run lint"
 
   vet-dependency-security:
-    needs: [pr-norm-branch, build-and-push-branch-devenv]
+    needs: [pr-norm-branch, buildx-and-push-branch-devenv]
     runs-on: ubuntu-latest
     env:
       DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
@@ -63,7 +65,7 @@ jobs:
         run: "APP_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -d ./script/run depsecscan"
 
   vet-static-security:
-    needs: [pr-norm-branch, build-and-push-branch-devenv]
+    needs: [pr-norm-branch, buildx-and-push-branch-devenv]
     runs-on: ubuntu-latest
     env:
       DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
@@ -73,7 +75,7 @@ jobs:
         run: "APP_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -d ./script/run statsecscan"
 
   vet-unit-tests:
-    needs: [pr-norm-branch, build-and-push-branch-devenv]
+    needs: [pr-norm-branch, buildx-and-push-branch-devenv]
     runs-on: ubuntu-latest
     env:
       DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
@@ -86,7 +88,7 @@ jobs:
         run: "APP_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -d ./script/run tests"
 
   vet-swagger-file-currency:
-    needs: [pr-norm-branch, build-and-push-branch-devenv]
+    needs: [pr-norm-branch, buildx-and-push-branch-devenv]
     runs-on: ubuntu-latest
     env:
       DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
@@ -101,7 +103,7 @@ jobs:
         run: git diff --exit-code swagger
 
   vet-deploy-as-e2e-tests-target:
-    needs: [pr-norm-branch, build-and-push-branch-unvetted]
+    needs: [pr-norm-branch, buildx-and-push-branch-unvetted]
     runs-on: ubuntu-latest
     env:
       UNVETTED_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
@@ -122,21 +124,19 @@ jobs:
       - vet-static-security
       - vet-dependency-security
       - vet-code-standards
-      - build-and-push-branch-unvetted
+      - buildx-and-push-branch-unvetted
       - pr-norm-branch
-    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@main
     with:
-      # Pull unvetted branch image
-      pull_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
-      # Push Vetted Image
-      push_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}:${{ github.event.pull_request.head.sha }}
+      source_image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
+      target_image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}:${{ github.event.pull_request.head.sha }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
 # Vet Dev Environment Image
   vet-devenv-as-e2e-tests-target:
-    needs: [pr-norm-branch, build-and-push-branch-devenv]
+    needs: [pr-norm-branch, buildx-and-push-branch-devenv]
     runs-on: ubuntu-latest
     env:
       DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/on_push_to_main_promote_to_prod.yml
+++ b/.github/workflows/on_push_to_main_promote_to_prod.yml
@@ -32,19 +32,17 @@ jobs:
 
   promote-branch-last-commit-to-prod:
     needs: [branch-and-last-commit, push-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@main
     with:
-      # Pull last (vetted) branch image
-      pull_as: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
-      # Push prod Image
-      push_as: ${{ github.repository }}:${{ needs.branch-and-last-commit.outputs.commit }}
+      source_image: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
+      target_image: ${{ github.repository }}:${{ needs.branch-and-last-commit.outputs.commit }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   promote-branch-last-commit-to-prod-latest:
     needs: [branch-and-last-commit, promote-branch-last-commit-to-prod]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_latest_image.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@main
     with:
       image_name: ${{ github.repository }}
       image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}
@@ -54,19 +52,17 @@ jobs:
 
   promote-branch-last-commit-devenv:
     needs: [branch-and-last-commit, push-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@main
     with:
-      # Pull last branch devenv image
-      pull_as: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}_dev:${{ needs.branch-and-last-commit.outputs.commit }}
-      # Push prod devenv image
-      push_as: ${{ github.repository }}-dev:${{ needs.branch-and-last-commit.outputs.commit }}
+      source_image: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}_dev:${{ needs.branch-and-last-commit.outputs.commit }}
+      target_image: ${{ github.repository }}-dev:${{ needs.branch-and-last-commit.outputs.commit }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   promote-branch-last-commit-devenv-to-latest:
     needs: [branch-and-last-commit, promote-branch-last-commit-devenv]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_latest_image.yml@main
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@main
     with:
       image_name: ${{ github.repository }}-dev
       image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,10 @@ RUN apt-get update \
   && apt-get -y dist-upgrade \
   && apt-get -y install ${DEVENV_PACKAGES} \
   && rm -rf /var/lib/apt/lists/* \
+  # Add support for multiple platforms
+  && bundle lock --add-platform ruby \
+  && bundle lock --add-platform x86_64-linux \
+  && bundle lock --add-platform aarch64-linux \
   # Install app dependencies
   && bundle install \
     # Remove unneeded files (cached *.gem, *.o, *.c)
@@ -71,6 +75,10 @@ FROM base-builder AS deploy-builder
 ARG BUNDLER_PATH=/usr/local/bundle
 
 RUN bundle config set --local without 'development:test' \
+    # Add support for multiple platforms
+    && bundle lock --add-platform ruby \
+    && bundle lock --add-platform x86_64-linux \
+    && bundle lock --add-platform aarch64-linux \
     && bundle install \
     # Remove unneeded files (cached *.gem, *.o, *.c)
     && rm -rf ${BUNDLER_PATH}/cache/*.gem \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,7 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.5)
     minitest (5.20.0)
     msgpack (1.7.2)
     net-imap (0.3.7)
@@ -146,6 +147,11 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.4)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.15.4-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
@@ -280,6 +286,8 @@ GEM
     zeitwerk (2.6.11)
 
 PLATFORMS
+  aarch64-linux
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ health status of the application:
   (e.g. http://localhost:3000/readyz)
 
 ## Running the Application
+> :apple: The images built for this project are multi-platform
+> images that support both `linux/amd64` (e.g. x86) and
+> `linux/arm64` (i.e. Apple Silicon)
+
 The easiest way to run the application is with the docker compose
 framework using the `dockercomposerun` script.
 

--- a/docs/OPERATING.md
+++ b/docs/OPERATING.md
@@ -1,8 +1,7 @@
 ## Operating random_thoughts_api
 
-> :eyes: Please see the [PREREQUISITES.md](docs/PREREQUISITES.md)
+> :eyes: Please see the [PREREQUISITES.md](PREREQUISITES.md)
 > for running and operating this application
-
 
 ### Database
 This project uses a Rails-supported PostgreSQL database with


### PR DESCRIPTION
 # What
This changeset adds support for Apple Silicon by creating `linux/arm64` images in CI in addition to the `linux/amd64` image.  This is based on prior art brianjbayer/sample-login-watir-cucumber#79

Specifically...
* Updates the Gemfile.lock to add `ruby` and `aarch64-linux`
* Updates CI workflows to use the multi-architecture actions to build the `linux/arm64` and `linux/amd64` images

# Why
This makes life easier for Apple Silicon based development and operations.

# Change Impact Analysis and Testing

## Testing Deploy Image
```
APP_IMAGE=brianjbayer/random_thoughts_api_linux-arm64-support:89fa9bc7b32648c4ad782ad98a0196e60946fbd3 ./script/dockercomposerun -c
```

## Testing Dev Image
```
APP_IMAGE=brianjbayer/random_thoughts_api_linux-arm64-support_dev:89fa9bc7b32648c4ad782ad98a0196e60946fbd3 ./script/dockercomposerun -d
```

- [x] PR CI Checks vet PR actions
  - [x] Verify `linux/arm64` and `linux/amd64` images in Docker Hub
- [ ] Merge checks will only vet those changes to main branch on merge 😦 

- [x] Verify `dockercompose` framework and branch images run locally
  - [x] Apple Silicon
    - [x] Dev image
    - [x] Deploy Image
  - [x] x86 (CI)
    - [x] Dev image
    - [x] Deploy Image

- [x] Documentation changes inspected on branch