### PR TITLE
Update Base Image to Debian Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # docker run -it --rm -v $(pwd):/app -p 3000:3000 rta-dev
 
 # --- Base Image ---
-ARG BASE_IMAGE=ruby:3.2.2-slim-bullseye
+ARG BASE_IMAGE=ruby:3.2.2-slim-bookworm
 FROM ${BASE_IMAGE} AS ruby-base
 
 #--- Base Builder Stage ---


### PR DESCRIPTION
# What
This changeset updates the base image to latest Debian release Bookworm (version 12).

# Why
Currency

# Change Impact Analysis and Testing
This changeset is limited to the project image.

- [x] CI Checks vet images build and execute with no operational or functional regressions
  - [x] CI Checks vet `amd64` images execute with no operational or functional regressions
- [x] Running `arm64` image on Apple Silicon vets `arm64` images execute with no operational or functional regressions
  - [x] Deploy Image:  `APP_IMAGE=brianjbayer/random_thoughts_api_update-base-image-debian-bookworm:54e320ffa0dba269a804a75eabd9b920af1d09d6 ./script/dockercomposerun -c`
  - [x] Dev Env Image: `APP_IMAGE=brianjbayer/random_thoughts_api_update-base-image-debian-bookworm_dev:54e320ffa0dba269a804a75eabd9b920af1d09d6 ./script/dockercomposerun -d`
