### PR TITLE
Better practices

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -113,7 +113,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: dockercomposerun e2e tests against unvetted image
-        run: "APP_IMAGE=${UNVETTED_IMAGE} ./script/dockercomposerun -ct"
+        run: "APP_IMAGE=${UNVETTED_IMAGE} ./script/dockercomposerun -ce"
 
   # Push (IF) Vetted Deploy Image
   push-branch-vetted-deploy-image:
@@ -147,4 +147,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: dockercomposerun e2e tests against devenv image
-        run: "APP_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -dt"
+        run: "APP_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -de"

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ FROM devenv-builder AS devenv
 WORKDIR /app
 
 # Start devenv in (command line) shell
-CMD bash
+CMD ["bash"]
 
 #--- Deploy Builder Stage ---
 FROM base-builder AS deploy-builder
@@ -113,4 +113,4 @@ COPY --from=deploy-builder --chown=deployer /usr/local/bundle/ /usr/local/bundle
 COPY --chown=deployer . /app/
 
 # Run the server with any required setup
-CMD ./entrypoint.sh
+CMD ["./entrypoint.sh"]

--- a/docker-compose.perf.yml
+++ b/docker-compose.perf.yml
@@ -1,17 +1,20 @@
 version: '3.8'
 services:
   app:
+    # Ensure that the app server is running
     command: ./entrypoint.sh
 
   perftests:
-    image: "${PERFTESTS_IMAGE:-grafana/k6:latest}"
-    container_name: ${PERFTESTS_HOSTNAME:-perftests}
+    image: "${PERF_IMAGE:-grafana/k6:latest}"
+    container_name: ${PERF_HOSTNAME:-perftests}
     environment:
-      - PERF_BASE_URL=http://${APP_HOSTNAME:-app}:${PORT:-3000}
+      - APP_BASE_URL=http://${APP_HOSTNAME:-app}:${PORT:-3000}
     volumes:
-      # Mount the k6 script to run
-      - ${PERFTESTS_SCRIPT:-./k6/script.js}:/script.js
-    command: run /script.js
+      # Mount the k6 script source directory
+      - ${PERF_SRC:-./k6}:/k6
+    working_dir: /k6
+    # Default entrypoint is k6 Alpine base
+    # entrypoint: "/bin/ash"
     depends_on:
       app:
         condition: service_healthy

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -94,19 +94,19 @@ framework, use the `dockercomposerun` script with the `-c`
 You can also run the
 [random_thoughts_api_e2e](https://github.com/brianjbayer/random_thoughts_api_e2e)
 End-to-End (E2E) tests using the `dockercomposerun` script with
-the `-t` (E2E tests) option.  This will pull the pinned E2E
+the `-e` (E2E tests) option.  This will pull the pinned E2E
 tests image and run them against the running application container.
 
 To run the E2E tests against the development environment, run the
 following command...
 ```
-RAILS_ENV=development ./script/dockercomposerun -dt
+RAILS_ENV=development ./script/dockercomposerun -de
 ```
 
 To run the E2E tests against your own deployment image, run the
 following command...
 ```
-APP_IMAGE=rta ./script/dockercomposerun -ct
+APP_IMAGE=rta ./script/dockercomposerun -ce
 ```
 
 ### Running the Perf Tests
@@ -115,12 +115,16 @@ script with the `-p` (Perf tests) option.  This will pull the
 [grafana/k6](https://k6.io/) load test tool image and run the
 specified test script against the running application container.
 
-To specify the tests script, use the `PERFTESTS_SCRIPT` environment
-variable (e.g. `PERFTESTS_SCRIPT=./k6/user_create_stress_test.js`)
+The grafana/k6 container runs the k6 application as its entrypoint,
+so it expects a k6 command e.g. `new`, `run user_create_stress_test.js`.
 
-To run the load test for creating a user, run the following command...
+To specify the tests script directory, use the `PERF_SRC` environment
+variable (e.g. `PERF_SRC=./k6`)
+
+For example, to run the load test script `user_create_stress_test.js`
+located in your `k6` subdirectory, run the following command...
 ```
-PERFTESTS_SCRIPT=./k6/user_create_stress_test.js ./script/dockercomposerun -p
+PERF_SRC=./k6 ./script/dockercomposerun -p "run" "user_create_stress_test.js"
 ```
 
 ### Operating

--- a/k6/random_thoughts_index_stress_test.js
+++ b/k6/random_thoughts_index_stress_test.js
@@ -17,7 +17,7 @@ export const options = {
 };
 
 export default function () {
-  const res = http.get(`${__ENV.PERF_BASE_URL}/v1/random_thoughts/`);
+  const res = http.get(`${__ENV.APP_BASE_URL}/v1/random_thoughts/`);
   check(res, {
     'is status 200': (r) => r.status === 200,
   });

--- a/k6/user_create_stress_test.js
+++ b/k6/user_create_stress_test.js
@@ -13,7 +13,7 @@ export const options = {
 };
 
 export default function () {
-  const create_user_url = `${__ENV.PERF_BASE_URL}/v1/users/`;
+  const create_user_url = `${__ENV.APP_BASE_URL}/v1/users/`;
   const payload = JSON.stringify({
     user: {
       email: `${uuidv4()}@test.org`,

--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -1,170 +1,105 @@
 #!/bin/sh
-# ----------------------------------------------------------------------
-# This script runs the project docker-compose framework.
-#
-# - The arguments to this script are passed to the app service
-#   as command override
-#
-# - Any environment variables set when calling this script are passed
-#   through to the docker-compose framework
-#   (e.g. configuration other than the defaults)
-#
-# OPTIONS:
-# -c: Use the docker-compose CI environment with APP_IMAGE
-# -d: Use the docker-compose Dev environment with APP_IMAGE
-# -n: No application database in the docker-compose environment
-# -p: Run the performance tests (and not the app service)
-# -t: Run the e2e tests (and not the app service)
-# ----------------------------------------------------------------------
+set -e
 
 usage() {
-  echo "Usage: $0 [-cdnpt] [CMD]"
+  cat << USAGE
+Usage: $0 [-cdehop] [CMD]
+This script orchestrates 'docker compose run app' using the docker compose framework
+  * Arguments are passed to the app service as the CMD (entrypoint)
+  * Environment variables override app and framework defaults
+
+OPTIONS: (in override order)
+  -o: Run only the application (no other services)
+  -d: Run the docker-compose Dev environment
+  -c: Run the docker-compose CI environment (must specify APP_IMAGE)
+
+Other Options:
+  -e: Run the e2e tests (against the app service)
+  -p: Run the performance tests (against the app service)
+USAGE
 }
 
 err_exit() {
-  local err_msg="$1"
-  local err_code=$2
+  err_code=$1
+  err_msg="$2"
   echo "${err_msg}  --  Exit:[${err_code}]" 1>&2
-  usage
   exit $err_code
 }
 
-# Exit script on any errors
-set -e
-
 # Handle options
-while getopts ":cdnpt" options; do
+while getopts ":cdehop" options; do
   case "${options}" in
     c)
-      echo "CI Environment"
-      ci=true
+      ci=1
       ;;
-
     d)
-      echo "Development Environment"
-      devenv=true
+      devenv=1
       ;;
-
-    n)
-      echo "No Database"
-      no_database=true
+    e)
+      run_e2etests=1
       ;;
-
+    h)
+      usage ; exit
+      ;;
+    o)
+      app_only=1
+      ;;
     p)
-      echo "Running Perf Tests"
-      run_perftests=true
+      run_perftests=1
       ;;
-
-    t)
-      echo "Running End-To-End (E2E) Tests"
-      run_e2etests=true
-      ;;
-
     \?)
-    err_exit "Invalid Option: -$OPTARG" 1
+      usage
+      err_exit 1 "Invalid Option: -$OPTARG"
       ;;
   esac
 done
 shift $((OPTIND-1))
 
-if [ ! -z ${run_perftests} ] && [ ! -z ${run_e2etests} ]; then
-echo ''
-echo "ERROR: you can not select both the '-p' (Perf Tests) and '-t' (End-To-End Tests) options!!!"
-exit 86
-fi
+[ ! -z ${run_perftests+x} ] && [ ! -z ${run_e2etests} ] \
+  && err_exit 2 "Can not use both '-e' and '-p' options"
 
-echo ''
-echo "ENVIRONMENT VARIABLES..."
-env
-echo ''
+echo "DOCKER VERSION: [`docker --version`]"
 
-echo 'DOCKER (COMPOSE) VERSION...'
-docker --version
-echo ''
-
-# Initial docker compose command before environments
 docker_compose_command='docker compose -f docker-compose.yml '
+[ -z ${app_only} ] && docker_compose_command="${docker_compose_command} -f docker-compose.db.yml "
+[ ! -z ${devenv} ] && docker_compose_command="${docker_compose_command} -f docker-compose.dev.yml "
+[ ! -z ${ci} ] && docker_compose_command="${docker_compose_command} -f docker-compose.ci.yml "
 
-# Unless the no database option is set, add the database service
-if [ -z ${no_database} ]; then
-  echo "...Adding Database to Environment"
-  docker_compose_command="${docker_compose_command} -f docker-compose.db.yml "
-fi
-
-if [ ! -z ${ci} ]; then
-  echo "...Using CI Environment with Image [${APP_IMAGE}]"
-  docker_compose_command="${docker_compose_command} -f docker-compose.ci.yml "
-fi
-
-if [ ! -z ${devenv} ]; then
-  echo "...Using Development Environment with Image [${APP_IMAGE}]"
-  docker_compose_command="${docker_compose_command} -f docker-compose.dev.yml "
-fi
+# Default is to run the app, but must specify --service-ports
+# (by default docker compose run does not expose host ports)
+run_command='run --rm --service-ports app '
 
 if [ ! -z ${run_perftests} ]; then
-  echo "...Running Perf Tests Image [${PERFTESTS_IMAGE}] against Image [${APP_IMAGE}]"
   docker_compose_command="${docker_compose_command} -f docker-compose.perf.yml "
+  run_command='run --rm perftests '
 fi
 
 if [ ! -z ${run_e2etests} ]; then
-  echo "...Running E2E Tests Image [${E2ETESTS_IMAGE}] against Image [${APP_IMAGE}]"
   docker_compose_command="${docker_compose_command} -f docker-compose.e2e.yml "
+  run_command='run --rm e2etests '
 fi
-echo ''
 
-echo "DOCKER-COMPOSE COMMAND: [${docker_compose_command}]"
-echo ''
+docker_compose_run_command="${docker_compose_command} ${run_command}"
+echo "DOCKER COMPOSE RUN COMMAND: [${docker_compose_run_command}]"
 
-echo 'DOCKER-COMPOSE CONFIGURATION...'
+echo 'DOCKER COMPOSE CONFIGURATION...'
 $docker_compose_command config
-echo ''
 
-echo 'DOCKER-COMPOSE PULLING...'
-set +e
-$docker_compose_command pull
-echo '...Allowing pull errors (for local images)'
-set -e
-echo ''
+echo 'DOCKER COMPOSE PULLING...'
+set +e ; $docker_compose_command pull ; set -e
 
-echo 'DOCKER IMAGES...'
-docker images
-echo ''
-
-echo "DOCKER-COMPOSE RUNNING [$@]..."
+echo "DOCKER COMPOSE RUNNING [${docker_compose_run_command}] [$@]..."
 # Allow to fail but catch return code
 set +e
-if [ ! -z ${run_perftests} ]; then
-  echo "RUNNING THE PERF TESTS (perftests SERVICE) (NOT app SERVICE)..."
-  $docker_compose_command run --rm perftests "$@"
-  # NOTE return code must be caught before any other command
-  run_return_code=$?
-elif [ ! -z ${run_e2etests} ]; then
-  echo "RUNNING THE E2E TESTS (e2etests SERVICE) (NOT app SERVICE)..."
-  $docker_compose_command run --rm e2etests "$@"
-  # NOTE return code must be caught before any other command
-  run_return_code=$?
-else
-  # Specify the --service-ports option to expose app's PORTS
-  # on host machine (by default docker-compose run does not
-  # expose host ports)
-  $docker_compose_command run --rm --service-ports app "$@"
-  # NOTE return code must be caught before any other command
-  run_return_code=$?
-fi
+${docker_compose_run_command} "$@"
+run_return_code=$?
 set -e
-echo ''
 
-if [ $run_return_code -eq 0 ]; then
-  run_disposition='PASSED'
-else
-  run_disposition='FAILED'
-fi
-echo "...RUN [${run_disposition}] WITH RETURN CODE [${run_return_code}]"
-echo ''
+run_disposition='SUCCESS' ; [ $run_return_code -eq 0 ] || run_disposition='FAIL'
+echo "DOCKER COMPOSE RUN [${run_disposition}] WITH RETURN CODE [${run_return_code}]"
 
 echo 'DOCKER-COMPOSE DOWN...'
 $docker_compose_command down
-echo ''
 
-echo "EXITING WITH ${run_disposition} RUN RETURN CODE ${run_return_code}"
+echo "EXIT: ${run_disposition} [${run_return_code}]"
 exit $run_return_code


### PR DESCRIPTION
# What
This changeset applies some better practices to the image and dockercompose framework and solidifies running the perftests.

* Use "exec" style for `CMD`
* More accurate and consistent environment variable naming
* Fix perftest service volume mounting to directory of scripts
* Refactor `dockercomposerun` script
  * rename `-n` (no) option to `-o` ( app only)
  * rename -`t` (e2e tests) to `-e` (e2e)

# Why
Less code and updated documentation

# Change Impact Analysis and Testing
Areas affected by the changes...
- Image building
- `dockercomposerun` script
  - e2e tests
- Perf scripts
  - `PERF_IMAGE`
  - `APP_BASE_URL`
  - Both scripts
- Documentation 

## Testing
- [x] CI Checks vet...
  - [x] Image building
  - [x] `dockercomposerun` orchestration using...
    - [x] deployment image
    - [x] development environment image
    - [x] e2e tests
    - [x] CI option `-c`

Local testing...
- [x] `./script/dockercomposerun -h` displays help
- [x] `./script/dockercomposerun -p "run" "user_create_stress_test.js"`
- [x] `./script/dockercomposerun -p "run" "random_thoughts_index_stress_test.js"`
- [x] Inspection of Rendering of updated documentation on this branch
