### PR TITLE
Refactor Secrets and Database Configuration

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -79,9 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
-      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-      SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
-      APP_JWT_SECRET: ${{ secrets.APP_JWT_SECRET }}
+      RAILS_ENV: test
     steps:
       - uses: actions/checkout@v1
       - name: dockercomposerun tests on development environment
@@ -92,9 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
-      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-      SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
-      APP_JWT_SECRET: not-used-but-needed
+      RAILS_ENV: test
     steps:
       - uses: actions/checkout@v1
       - name: dockercomposerun swaggerize on development environment
@@ -140,9 +136,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
-      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-      SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
-      APP_JWT_SECRET: ${{ secrets.APP_JWT_SECRET }}
       RAILS_ENV: development
     steps:
       - uses: actions/checkout@v1

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,8 +19,13 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  url: <%= ENV['DATABASE_URL'] %>
+  pool: <%= ENV.fetch('RAILS_MAX_THREADS') { 5 } %>
+
+  host: <%= ENV['POSTGRES_HOST'] %>
+  port: <%= ENV['PGPORT'] %>
+  database: <%= ENV['POSTGRES_DB'] %>
+  username: <%= ENV['POSTGRES_USER'] %>
+  password: <%= ENV['POSTGRES_PASSWORD'] %>
 
 development:
   <<: *default

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -1,7 +1,12 @@
 services:
   app:
     environment:
-      DATABASE_URL: postgresql://random_thoughts_api:${POSTGRES_PASSWORD:-banana}@db:5432/random_thoughts_api
+      PGPORT: ${PGPORT:-5432}
+      # Default host is the db service
+      POSTGRES_HOST: ${POSTGRES_HOST:-db}
+      POSTGRES_DB: ${POSTGRES_DB:-random_thoughts_api}
+      POSTGRES_USER: ${POSTGRES_USER:-random_thoughts_api}
+      POSTGRES_PASSWORD:
     depends_on:
       db:
         condition: service_healthy
@@ -9,17 +14,20 @@ services:
   db:
     image: postgres
     environment:
+      # PostgreSQL environment variables
+      # By default Postgres runs on port 5432
+      PGPORT: ${PGPORT:-5432}
+      # Postgres image environment variables
       POSTGRES_HOST_AUTH_METHOD: md5
-      POSTGRES_DB: random_thoughts_api
-      POSTGRES_USER: random_thoughts_api
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-banana}
-    # By default Postgres runs on port 5432,
-    # map this to localhost port 5432 for access
+      POSTGRES_DB: ${POSTGRES_DB:-random_thoughts_api}
+      POSTGRES_USER: ${POSTGRES_USER:-random_thoughts_api}
+      POSTGRES_PASSWORD:
     ports:
-    - "5432:5432"
-    # Expose 5432 to other containers in this network
+    # Maps to host localhost port 5432
+    - "${PGPORT:-5432}:5432"
+    # Expose Port to other containers in this network
     expose:
-    - "5432"
+    - ${PGPORT:-5432}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]
       interval: 10s

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,3 +3,16 @@ services:
     image: "${APP_IMAGE:-brianjbayer/random_thoughts_api-dev:latest}"
     volumes:
       - ${APP_SRC:-.}:/app
+    environment:
+      RAILS_ENV: ${RAILS_ENV:-development}
+      POSTGRES_DB: "${POSTGRES_DB:-random_thoughts_api}_${RAILS_ENV:-development}"
+      # For development environment use default secrets
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-banana}
+      # To generate secret keys `openssl rand -hex 64`
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE:-dev_b2b05a5b3793a9d416fecb7799b662826aadf190729987055bfb794ba474ba5582187d238f8b4d851e8af02885737a26d370243458dac53ce29fb6dbcfc140ac}
+      APP_JWT_SECRET: ${APP_JWT_SECRET:-dev_2748a9c0fa8244a555620c075aa7902e1fae951fee1a5f30fa9f96a3d8a7e9d48594a83ec5af6af6b7aeef6da8e021fce44106206b3dce3c174beeaa5420ab33}
+
+  db:
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-random_thoughts_api}_${RAILS_ENV:-development}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-banana}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -37,6 +37,9 @@ the docker compose framework using the `dockercomposerun` script with the
 This will pull and run the latest development environment image
 of this project along with the latest `postgres` image.
 
+> :fast_forward: The docker compose framework provides default
+> values for `SECRET_KEY_BASE` and `APP_JWT_SECRET` for you
+
 To exit the containerized development environment, run the
 following command ...
 ```


### PR DESCRIPTION
# What
This changeset modifies...
* Secret management in the docker compose dev environment by adding default secrets so that they not required to be passed by CI when running tests and eliminate the want for a local `.env` file
* Changes the PostgreSQL Database configuration to separate environment variables instead of the previous database URL and
  * Adds PostgreSQL standard `PGPORT` environment variable support
  * Adds `RAILS_ENV` to database name in dockercompose dev environment

# Why
Default secrets in dev environment validate functionality and eliminate the need for these not-really "secrets" to be passed in CI.  This reduces complexity and allows the tests to run without any secret or other environment variable dependencies.

The more standard RAILS (PostgreSQL image) environment variable configuration although more verbose is better suited to secret management and separation of concerns than the Database URL.

# Change Impact Analysis and Testing
- [x] CI Checks vet dockercompose and database functionality
- [x] Manual inspection of updated documentation rendered on the branch view
