### PR TITLE
Use Cross-Compilation in Multi Platform Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # --- Base Image ---
 # Ruby version must mttch that in Gemfile.lock
 ARG BASE_IMAGE=ruby:3.2.4-slim-bookworm
-FROM ${BASE_IMAGE} AS ruby-base
+FROM --platform=$BUILDPLATFORM ${BASE_IMAGE} AS ruby-base
 
 #--- Base Builder Stage ---
 FROM ruby-base AS base-builder


### PR DESCRIPTION
# What & Why
This is a one-line change to the `Dockerfile` to use *cross-compiltion* to decrease the elapsed time of multi-platform builds (especially in CI) as reommended in the [Faster Multi-Platform Builds: Dockerfile Cross-Compilation Guide](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide) by Docker.

# Change Impact Analysis and Testing
This change is to the `Dockerfile` in a container-native project.  Building and operating both the `linux/amd64` (CI) and `linux/arm64` (local Apple Silicon) images as well as full functional regression is warranted.

- [x] Confirm Dev and Deploy image platform `linux/arm64` on Apple Silicon, for example...
  ```
  docker pull brianjbayer/random_thoughts_api_cross-compile-in-multiplatform-builds_dev:COMMIT
  docker inspect brianjbayer/random_thoughts_api_cross-compile-in-multiplatform-builds_dev:COMMIT
  ```
- [x] CI Checks vets both operation and functionality of the `linux/amd64` platform
- [x] Local (Apple Silicon) build and operation of dev image
- [x] Local (Apple Silicon) build and operation of deploy image
- [x] Local (Apple Silicon) operation and regression testing vets `linux/arm64` platform
  - [x] Dev image...
    - [x] Tests and CI vettings
    - [x] Server
  - [x] Deploy image...
    - [x] Server