### PR TITLE
Revert False Cross-Compilation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # --- Base Image ---
 # Ruby version must mttch that in Gemfile.lock
 ARG BASE_IMAGE=ruby:3.2.4-slim-bookworm
-FROM --platform=$BUILDPLATFORM ${BASE_IMAGE} AS ruby-base
+FROM ${BASE_IMAGE} AS ruby-base
 
 #--- Base Builder Stage ---
 FROM ruby-base AS base-builder


### PR DESCRIPTION
# What
This one-line change reverts brianjbayer/random_thoughts_api#83 by removing `--platform=$BUILDPLATFORM` from the `Dockerfile` base image directive.

# Why
The `--platform=$BUILDPLATFORM` causes a false build of the `linux/arm64` platform image using the `BUILDPLATFORM` which is `linux/amd64` (ubuntu runner) .  This reverts that regression.  Note that most operations do still work but only by chance.

# Change Impact Analysis and Testing
This simply takes things back to before brianjbayer/random_thoughts_api#83

- [x] Verify there is no difference between this comimit and (merge) commit prior to brianjbayer/random_thoughts_api#83 with `git diff 8e7722fbd7c035dcf3f527bcad80cae7ac900e45..HEAD` returning empty
