### PR TITLE
Fix Ability To Run Docker Compose Dev Environment Without Database

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -51,9 +51,9 @@ jobs:
       - buildx-and-push-dev-image
     uses: brianjbayer/actions-image-cicd/.github/workflows/vet_code_standards.yml@v0.2.1
     with:
-      lint_command: "APP_IMAGE=${{ needs.image-names.outputs.dev_image }} ./script/dockercomposerun -d ./script/run lint"
-      dependency_security_command: "APP_IMAGE=${{ needs.image-names.outputs.dev_image }} ./script/dockercomposerun -d ./script/run depsecscan"
-      static_security_command: "APP_IMAGE=${{ needs.image-names.outputs.dev_image }} ./script/dockercomposerun -d ./script/run statsecscan"
+      lint_command: "APP_IMAGE=${{ needs.image-names.outputs.dev_image }} ./script/dockercomposerun -do ./script/run lint"
+      dependency_security_command: "APP_IMAGE=${{ needs.image-names.outputs.dev_image }} ./script/dockercomposerun -do ./script/run depsecscan"
+      static_security_command: "APP_IMAGE=${{ needs.image-names.outputs.dev_image }} ./script/dockercomposerun -do ./script/run statsecscan"
       tests_command: "RAILS_ENV=test APP_IMAGE=${{ needs.image-names.outputs.dev_image }} ./script/dockercomposerun -d ./script/run tests"
 
   vet-swagger-file-currency:

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -4,9 +4,9 @@ services:
       PGPORT: ${PGPORT:-5432}
       # Default host is the db service
       POSTGRES_HOST: ${POSTGRES_HOST:-db}
-      POSTGRES_DB: ${POSTGRES_DB:-random_thoughts_api}
+      POSTGRES_DB: "${POSTGRES_DB:-random_thoughts_api}_${RAILS_ENV:-development}"
       POSTGRES_USER: ${POSTGRES_USER:-random_thoughts_api}
-      POSTGRES_PASSWORD:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-banana}
     depends_on:
       db:
         condition: service_healthy
@@ -19,9 +19,9 @@ services:
       PGPORT: ${PGPORT:-5432}
       # Postgres image environment variables
       POSTGRES_HOST_AUTH_METHOD: md5
-      POSTGRES_DB: ${POSTGRES_DB:-random_thoughts_api}
+      POSTGRES_DB: "${POSTGRES_DB:-random_thoughts_api}_${RAILS_ENV:-development}"
       POSTGRES_USER: ${POSTGRES_USER:-random_thoughts_api}
-      POSTGRES_PASSWORD:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-banana}
     ports:
     # Maps to host localhost port 5432
     - "${PGPORT:-5432}:5432"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,14 +5,6 @@ services:
       - ${APP_SRC:-.}:/app
     environment:
       RAILS_ENV: ${RAILS_ENV:-development}
-      POSTGRES_DB: "${POSTGRES_DB:-random_thoughts_api}_${RAILS_ENV:-development}"
-      # For development environment use default secrets
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-banana}
       # To generate secret keys `openssl rand -hex 64`
       SECRET_KEY_BASE: ${SECRET_KEY_BASE:-dev_b2b05a5b3793a9d416fecb7799b662826aadf190729987055bfb794ba474ba5582187d238f8b4d851e8af02885737a26d370243458dac53ce29fb6dbcfc140ac}
       APP_JWT_SECRET: ${APP_JWT_SECRET:-dev_2748a9c0fa8244a555620c075aa7902e1fae951fee1a5f30fa9f96a3d8a7e9d48594a83ec5af6af6b7aeef6da8e021fce44106206b3dce3c174beeaa5420ab33}
-
-  db:
-    environment:
-      POSTGRES_DB: ${POSTGRES_DB:-random_thoughts_api}_${RAILS_ENV:-development}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-banana}


### PR DESCRIPTION
# What
This changeset moves the database environment variables all back into `docker-compose.db.yml` which fixes the ability to run `dockercomposerun -do`.

# Why
This fixes an operational regression.

# Change Impact Analysis and Testing
PR checks have been updated to now use `dockercomposerun -do` which will verify this changeset.
