### PR TITLE
Fix `...FATAL:  role "root" does not exist` PostgreSQL Container Errors

### DIFF
--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -2,10 +2,10 @@ services:
   app:
     environment:
       PGPORT: ${PGPORT:-5432}
-      # Default host is the db service
+      # Is (matches) the db service
       POSTGRES_HOST: ${POSTGRES_HOST:-db}
-      POSTGRES_DB: "${POSTGRES_DB:-random_thoughts_api}_${RAILS_ENV:-development}"
-      POSTGRES_USER: ${POSTGRES_USER:-random_thoughts_api}
+      POSTGRES_DB: ${POSTGRES_DB:-random_thoughts_api}_${RAILS_ENV:-development}
+      POSTGRES_USER: ${POSTGRES_USER:-random_thoughts_api}_${RAILS_ENV:-development}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-banana}
     depends_on:
       db:
@@ -17,10 +17,13 @@ services:
       # PostgreSQL environment variables
       # By default Postgres runs on port 5432
       PGPORT: ${PGPORT:-5432}
+      # For happy container (logs), set internal user to POSTGRES_DB/POSTGRES_USER
+      PGUSER: ${PGUSER:-random_thoughts_api}_${RAILS_ENV:-development}
       # Postgres image environment variables
+      # To keep the pg container (logs) happy, make db and user the same
+      POSTGRES_DB: ${POSTGRES_DB:-random_thoughts_api}_${RAILS_ENV:-development}
+      POSTGRES_USER: ${POSTGRES_USER:-random_thoughts_api}_${RAILS_ENV:-development}
       POSTGRES_HOST_AUTH_METHOD: md5
-      POSTGRES_DB: "${POSTGRES_DB:-random_thoughts_api}_${RAILS_ENV:-development}"
-      POSTGRES_USER: ${POSTGRES_USER:-random_thoughts_api}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-banana}
     ports:
     # Maps to host localhost port 5432


### PR DESCRIPTION
# What & Why
This changeset addresses the `FATAL:  role "root" does not exist` errors occurring in the PostgreSQL (PG) containers and appearing in the logs. 

This sets all the PG container's following environment variables to the same default value in the docker compose framework...
* `POSTGRES_DB` - The app's database
* The `PG` `USER`s...
  * `PGUSER` - The internal user in PG
  * `POSTGRES_USER` - The PG image user environment variable

# Change Impact Analysis and Testing
These changes are only to the docker compose framework affecting containerized operation including CI (PR Checks).

## Changes

- [x] Verify locally that the changes on this branch stop the `FATAL` errors in the PG container's logs in the docker compose framework 
  - [x] Deploy: `./script/dockercomposerun`
  - [x] Dev: `./script/dockercomposerun -d`

### Reproduce Issue Being Fixed
In one terminal, on branch `main`, run the docker compose framework...
```
./script/dockercomposerun
```

In another terminal (or in Docker Desktop) examine the PG container's logs...
```
docker logs -f random_thoughts_api-db-1
```

and observe something like this...
```
...
2024-11-20 23:27:40.569 UTC [1] LOG:  database system is ready to accept connections
2024-11-20 23:27:50.023 UTC [74] FATAL:  role "root" does not exist
2024-11-20 23:28:00.068 UTC [84] FATAL:  role "root" does not exist
```



## Regressions
- [x] Successful PR Checks verifies no Regressions
