### PR TITLE
Add VS Code devcontainer Support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+  "name": "Sample Login DevContainer",
+
+  "dockerComposeFile": [
+    "../docker-compose.yml",
+    "../docker-compose.db.yml",
+    "../docker-compose.dev.yml"
+  ],
+
+  "service": "app",
+  "workspaceFolder": "/app",
+  "overrideCommand": true,
+
+  // "postStartCommand": "bundle install",
+  "remoteUser": "root",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "davidanson.vscode-markdownlint",
+        "eamodio.gitlens",
+        "github.vscode-github-actions",
+        "ms-azuretools.vscode-containers",
+        "ms-azuretools.vscode-docker",
+        "ms-vscode-remote.remote-containers",
+        "redhat.vscode-yaml",
+        "shopify.ruby-lsp",
+        "streetsidesoftware.code-spell-checker"
+      ],
+      "settings": {
+        "terminal.integrated.shell.linux": "bash",
+        "ruby.useBundler": true
+      }
+    }
+  },
+
+  "shutdownAction": "stopCompose"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+# Ignore IDEs (devcontainers)
+.vscode/
+
 # Ignore bundler config.
 /.bundle
 

--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -3,12 +3,13 @@ set -e
 
 usage() {
   cat << USAGE
-Usage: $0 [-cdhop] [CMD]
+Usage: $0 [-cdhkop] [CMD]
 This script orchestrates 'docker compose run app' using the docker compose framework
   * Arguments are passed to the app service as the CMD (entrypoint)
   * Environment variables override app and framework defaults
 
 OPTIONS: (in override order)
+  -k: docker compose down (kills) the specified environment
   -o: Run only the application (no other services)
   -d: Run the docker-compose Dev environment
   -c: Run the docker-compose CI environment (must specify APP_IMAGE)
@@ -26,7 +27,7 @@ err_exit() {
 }
 
 # Handle options
-while getopts ":cdhop" options; do
+while getopts ":cdhkop" options; do
   case "${options}" in
     c)
       ci=1
@@ -36,6 +37,9 @@ while getopts ":cdhop" options; do
       ;;
     h)
       usage ; exit
+      ;;
+    k)
+      kill=1
       ;;
     o)
       app_only=1
@@ -72,6 +76,14 @@ echo "DOCKER COMPOSE RUN COMMAND: [${docker_compose_run_command}]"
 
 echo 'DOCKER COMPOSE CONFIGURATION...'
 $docker_compose_command config
+
+if [ -n "${kill}" ] ; then
+  echo 'KILLING: DOCKER-COMPOSE DOWN...'
+  set +e
+  $docker_compose_command down
+  set -e
+  exit
+fi
 
 echo 'DOCKER COMPOSE PULLING...'
 set +e ; $docker_compose_command pull ; set -e


### PR DESCRIPTION
# What & Why
To make local (VS Code) development easier, this adds VS Code *devcontainer* development environment support complete with several extensions such as Shopify's Ruby-LSP.

This utilizes the existing docker compose development environment (e.g. `./script/dockercomposerun -d`) and adds a new `-k` option to `./script/dockercomposerun` to stop the devcontainer's stack with `./script/dockercomposerun -dk`.


# Change Impact Analysis and Testing
- [x] VS Code devcontainers environment properly starts with extensions
  - [x] In devcontainers terminal window can successfully run tests (`RAILS_ENV=test ./script/run tests`)
- [x] PR Checks verifies these change and that there are no regressions
